### PR TITLE
Externalize agent prompt templates to ~/.askcc/templates/

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/askcc-cli.iml
+++ b/.idea/askcc-cli.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="uv (askcc-cli)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyStubPackagesAdvertiser" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <list>
+          <option value="djangorestframework" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="uv (askcc-cli)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="uv (askcc-cli)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/askcc-cli.iml" filepath="$PROJECT_DIR$/.idea/askcc-cli.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ askcc [--cwd DIR] {plan,develop} --github-issue-url URL
 
 On first run, askcc creates `~/.askcc/templates/` with four default template files:
 
-| File                 | Description                          |
-|----------------------|--------------------------------------|
-| `plan_system.txt`    | System prompt for the planning agent |
-| `plan_user.txt`      | User prompt template for planning    |
-| `develop_system.txt` | System prompt for the dev agent      |
-| `develop_user.txt`   | User prompt template for development |
+| File                       | Required variables | Description                          |
+|----------------------------|--------------------|--------------------------------------|
+| `PLAN_SYSTEM_PROMPT.md`    | —                  | System prompt for the planning agent |
+| `PLAN_USER_PROMPT.md`      | `$issue_content`   | User prompt template for planning    |
+| `DEVELOP_SYSTEM_PROMPT.md` | —                  | System prompt for the dev agent      |
+| `DEVELOP_USER_PROMPT.md`   | `$issue_content`   | User prompt template for development |
 
-Edit any file to customize the agent's behavior. User prompt templates support the `$issue_content` variable, which is replaced with the fetched GitHub issue at runtime.
+Edit any file to customize the agent's behavior. User prompt templates **must** contain the `$issue_content` variable, which is replaced with the fetched GitHub issue at runtime. askcc validates this on startup and raises an error if a required variable is missing.
 
 Override the config directory by setting the `ASKCC_HOME` environment variable (e.g. for testing).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ A one-shot Claude Code CLI executor that fetches a GitHub issue and pipes it to 
 uv tool install . --python 3.14
 ```
 
+Or install directly from GitHub:
+
+```bash
+uv tool install git+https://github.com/monkut/askcc-cli.git --python 3.14
+```
+
 Or run directly with `uvx`:
 
 ```bash
@@ -46,7 +52,23 @@ askcc [--cwd DIR] {plan,develop} --github-issue-url URL
 
 | Variable    | Description                                | Default |
 |-------------|--------------------------------------------|---------|
-| `LOG_LEVEL` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, etc.) | `INFO`  |
+| `LOG_LEVEL`  | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, etc.) | `INFO`    |
+| `ASKCC_HOME` | Root directory for askcc configuration and templates   | `~/.askcc` |
+
+### Customizing Prompts
+
+On first run, askcc creates `~/.askcc/templates/` with four default template files:
+
+| File                 | Description                          |
+|----------------------|--------------------------------------|
+| `plan_system.txt`    | System prompt for the planning agent |
+| `plan_user.txt`      | User prompt template for planning    |
+| `develop_system.txt` | System prompt for the dev agent      |
+| `develop_user.txt`   | User prompt template for development |
+
+Edit any file to customize the agent's behavior. User prompt templates support the `$issue_content` variable, which is replaced with the fetched GitHub issue at runtime.
+
+Override the config directory by setting the `ASKCC_HOME` environment variable (e.g. for testing).
 
 ### Examples
 

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -44,8 +44,6 @@ def _run_claude(prompt: str, config: AgentConfig, *, cwd: Path | None = None) ->
 
 def main() -> None:
     configure_logging()
-    bootstrap_templates()
-
     parser = argparse.ArgumentParser(description="A one-shot Claude Code CLI executor.")
     parser.add_argument(
         "--version",
@@ -69,6 +67,7 @@ def main() -> None:
     develop_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to develop.")
 
     args = parser.parse_args()
+    bootstrap_templates()
 
     agent = AgentType(args.command)
     config = load_agent_config(agent)

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -63,6 +63,7 @@ class AgentConfig:
     user_prompt_template: str
     system_prompt_file: str
     user_prompt_file: str
+    required_variables: tuple[str, ...] = ()
 
 
 class AgentType(StrEnum):
@@ -76,15 +77,17 @@ AGENT_CONFIGS: dict[AgentType, AgentConfig] = {
         description="Plans implementation for given issue",
         system_prompt=PLAN_AGENT_PROMPT,
         user_prompt_template=PLAN_USER_PROMPT_TEMPLATE,
-        system_prompt_file="plan_system.txt",
-        user_prompt_file="plan_user.txt",
+        system_prompt_file="PLAN_SYSTEM_PROMPT.md",
+        user_prompt_file="PLAN_USER_PROMPT.md",
+        required_variables=("issue_content",),
     ),
     AgentType.DEVELOP: AgentConfig(
         agent_name="developer",
         description="Develops a planned/defined issue",
         system_prompt=DEVELOP_AGENT_PROMPT,
         user_prompt_template=DEVELOP_USER_PROMPT_TEMPLATE,
-        system_prompt_file="develop_system.txt",
-        user_prompt_file="develop_user.txt",
+        system_prompt_file="DEVELOP_SYSTEM_PROMPT.md",
+        user_prompt_file="DEVELOP_USER_PROMPT.md",
+        required_variables=("issue_content",),
     ),
 }

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 DEFAULT_LOG_LEVEL = "INFO"
 LOG_LEVEL = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
 
-ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME", str(Path.home() / ".askcc")))
+ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"
 
 

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -1,9 +1,13 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
 DEFAULT_LOG_LEVEL = "INFO"
 LOG_LEVEL = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
+
+ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME", str(Path.home() / ".askcc")))
+TEMPLATES_DIR: Path = ASKCC_HOME / "templates"
 
 
 def configure_logging() -> None:

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+from string import Template
+from typing import TYPE_CHECKING
+
 import pytest
 
-from askcc.functions import _parse_issue_url
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from askcc.definitions import AGENT_CONFIGS, AgentType
+from askcc.functions import _parse_issue_url, bootstrap_templates, load_agent_config, load_template
 
 
 class TestParseIssueUrl:
@@ -23,3 +32,97 @@ class TestParseIssueUrl:
         assert owner == "monkut"
         assert repo == "askcc-cli"
         assert issue_number == 7
+
+
+class TestBootstrapTemplates:
+    def test_bootstrap_creates_directory_and_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        bootstrap_templates()
+
+        assert templates_dir.is_dir()
+        expected_files = {"plan_system.txt", "plan_user.txt", "develop_system.txt", "develop_user.txt"}
+        actual_files = {f.name for f in templates_dir.iterdir()}
+        assert actual_files == expected_files
+
+    def test_bootstrap_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        bootstrap_templates()
+        first_run_contents = {f.name: f.read_text() for f in templates_dir.iterdir()}
+
+        bootstrap_templates()
+        second_run_contents = {f.name: f.read_text() for f in templates_dir.iterdir()}
+
+        assert first_run_contents == second_run_contents
+
+    def test_bootstrap_writes_correct_default_content(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        bootstrap_templates()
+
+        plan_config = AGENT_CONFIGS[AgentType.PLAN]
+        assert (templates_dir / "plan_system.txt").read_text() == plan_config.system_prompt
+        assert (templates_dir / "plan_user.txt").read_text() == plan_config.user_prompt_template
+
+
+class TestLoadTemplate:
+    def test_reads_custom_content(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir(parents=True)
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        custom_text = "My custom system prompt"
+        (templates_dir / "plan_system.txt").write_text(custom_text)
+
+        result = load_template("plan_system.txt", "fallback")
+        assert result == custom_text
+
+    def test_falls_back_on_missing_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir(parents=True)
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        result = load_template("nonexistent.txt", "default value")
+        assert result == "default value"
+
+
+class TestLoadAgentConfig:
+    def test_returns_disk_content(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+
+        bootstrap_templates()
+
+        custom_system = "Custom system prompt for plan"
+        (templates_dir / "plan_system.txt").write_text(custom_system)
+
+        config = load_agent_config(AgentType.PLAN)
+        assert config.system_prompt == custom_system
+        assert config.agent_name == "planner"
+
+    def test_preserves_non_template_fields(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentType.DEVELOP)
+        assert config.agent_name == "developer"
+        assert config.description == "Develops a planned/defined issue"
+
+
+class TestStringTemplateSubstitution:
+    def test_issue_content_substituted(self):
+        template_str = "Do the thing.\n\n$issue_content"
+        result = Template(template_str).safe_substitute(issue_content="Fix bug #42")
+        assert result == "Do the thing.\n\nFix bug #42"
+
+    def test_json_curly_braces_survive(self):
+        template_str = "Process this:\n\n$issue_content"
+        issue = '{"json": true, "nested": {"key": "value"}}'
+        result = Template(template_str).safe_substitute(issue_content=issue)
+        assert '{"json": true' in result
+        assert "$issue_content" not in result


### PR DESCRIPTION
## Summary

- Bootstrap `~/.askcc/templates/` on first run with four default prompt files (`plan_system.txt`, `plan_user.txt`, `develop_system.txt`, `develop_user.txt`), then load from disk at runtime so users can customize agent behavior without editing source code
- Switch user prompt templates from `str.format` to `string.Template` (`$issue_content`) so curly braces in custom templates survive
- Add `ASKCC_HOME` env-var override for config directory (enables test isolation)
- Document template customization and add `uv tool install git+...` command in README

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pyright` — clean
- [x] `uv run poe test` — 13 tests pass (9 new)
- [ ] Manual: remove `~/.askcc`, run `askcc --help`, confirm `~/.askcc/templates/` created with 4 files
- [ ] Manual: edit a template file, re-run, confirm custom text is used