### PR TITLE
Add review command for GitHub issue quality review

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uvx --from . --python 3.14 askcc --help
 ## Usage
 
 ```
-askcc [--cwd DIR] {plan,develop} --github-issue-url URL
+askcc [--cwd DIR] {plan,develop,review} --github-issue-url URL
 ```
 
 ### Commands
@@ -39,6 +39,7 @@ askcc [--cwd DIR] {plan,develop} --github-issue-url URL
 |-----------|--------------------------------------------------------------------|
 | `plan`    | Fetch the issue and run Claude in planning mode (architecture/design) |
 | `develop` | Fetch the issue and run Claude in development mode (implementation)   |
+| `review`  | Fetch the issue and run Claude in review mode (issue quality review)   |
 
 ### Options
 
@@ -57,7 +58,7 @@ askcc [--cwd DIR] {plan,develop} --github-issue-url URL
 
 ### Customizing Prompts
 
-On first run, askcc creates `~/.askcc/templates/` with four default template files:
+On first run, askcc creates `~/.askcc/templates/` with default template files:
 
 | File                       | Required variables | Description                          |
 |----------------------------|--------------------|--------------------------------------|
@@ -65,6 +66,8 @@ On first run, askcc creates `~/.askcc/templates/` with four default template fil
 | `PLAN_USER_PROMPT.md`      | `$issue_content`   | User prompt template for planning    |
 | `DEVELOP_SYSTEM_PROMPT.md` | —                  | System prompt for the dev agent      |
 | `DEVELOP_USER_PROMPT.md`   | `$issue_content`   | User prompt template for development |
+| `REVIEW_SYSTEM_PROMPT.md`  | —                  | System prompt for the review agent   |
+| `REVIEW_USER_PROMPT.md`    | `$issue_content`   | User prompt template for review      |
 
 Edit any file to customize the agent's behavior. User prompt templates **must** contain the `$issue_content` variable, which is replaced with the fetched GitHub issue at runtime. askcc validates this on startup and raises an error if a required variable is missing.
 

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -66,6 +66,9 @@ def main() -> None:
     develop_parser = subparsers.add_parser("develop", help="Run Claude in development mode.")
     develop_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to develop.")
 
+    review_parser = subparsers.add_parser("review", help="Run Claude in review mode (issue quality review).")
+    review_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to review.")
+
     args = parser.parse_args()
     bootstrap_templates()
 

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -45,6 +45,8 @@ EXPECTED_TEMPLATE_FILES = {
     "PLAN_USER_PROMPT.md",
     "DEVELOP_SYSTEM_PROMPT.md",
     "DEVELOP_USER_PROMPT.md",
+    "REVIEW_SYSTEM_PROMPT.md",
+    "REVIEW_USER_PROMPT.md",
 }
 
 
@@ -152,6 +154,15 @@ class TestLoadAgentConfig:
         config = load_agent_config(AgentType.DEVELOP)
         assert config.agent_name == "developer"
         assert config.description == "Develops a planned/defined issue"
+
+    def test_load_review_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentType.REVIEW)
+        assert config.agent_name == "reviewer"
+        assert config.description == "Reviews a GitHub issue for clarity, completeness, and feasibility"
 
     def test_raises_on_missing_required_variable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         templates_dir = tmp_path / "templates"


### PR DESCRIPTION
## Summary

- Add `askcc review --github-issue-url URL` command that evaluates GitHub issues for clarity, completeness, acceptance criteria, feasibility, and scope
- Posts structured, actionable feedback as a comment on the issue via `gh` CLI
- Follows the same pattern as existing `plan` and `develop` commands (enum value, agent config, system/user prompts, CLI subparser, template files)

## Test plan

- [x] `uv run poe test` — 19 tests pass (including new `test_load_review_config`)
- [x] `uv run poe check` — ruff lint clean
- [x] `uv run poe typecheck` — pyright clean
- [x] `askcc review --help` — shows review subcommand