### PR TITLE
Add explore and diagnose commands

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -69,6 +69,14 @@ def main() -> None:
     review_parser = subparsers.add_parser("review", help="Run Claude in review mode (issue quality review).")
     review_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to review.")
 
+    explore_parser = subparsers.add_parser(
+        "explore", help="Run Claude in explore mode (investigate and propose solutions)."
+    )
+    explore_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to explore.")
+
+    diagnose_parser = subparsers.add_parser("diagnose", help="Run Claude in diagnose mode (root cause analysis).")
+    diagnose_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to diagnose.")
+
     install_parser = subparsers.add_parser("install", help="Install bundled skills to the agent workspace.")
     install_parser.add_argument(
         "--directory",

--- a/askcc/skills/request-askcc/SKILL.md
+++ b/askcc/skills/request-askcc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-askcc
-description: Request REVIEW, PLAN or DEVELOP actions for GitHub issues via the askcc CLI. Use when a user asks to review, plan an implementation of a GitHub issue, or to proceed with development of a planned GitHub issue.
+description: Request REVIEW, PLAN, DEVELOP, EXPLORE or DIAGNOSE actions for GitHub issues via the askcc CLI. Use when a user asks to review, plan, develop, explore, or diagnose a GitHub issue.
 ---
 
 # Request GitHub Issue Action
@@ -11,7 +11,9 @@ Use the `askcc` tool to request processing (plan or develop) of GitHub issues de
 
 - When a user asks to PLAN an implementation of a given GitHub issue, use `askcc plan`.
 - When a user asks to DEVELOP a planned implementation defined in a given GitHub issue, use `askcc develop`.
-- When a user ask to REVIEW a github issue, use `askcc review`.
+- When a user asks to REVIEW a github issue, use `askcc review`.
+- When a user asks to EXPLORE a github issue (investigate and propose solutions), use `askcc explore`.
+- When a user asks to DIAGNOSE a github issue (root cause analysis), use `askcc diagnose`.
 
 ## Examples
 
@@ -35,6 +37,20 @@ Use the `askcc` tool to request processing (plan or develop) of GitHub issues de
   ```bash
   # This fetches the specified GitHub issue and runs Claude in review mode to assess issue quality and completeness. 
   askcc review --github-issue-url  https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1                                           
+  ```
+
+- "Explore https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1"
+
+  ```bash
+  # This investigates the github issue, researches the codebase, and proposes best-practice solutions with trade-offs.
+  askcc explore --cwd {PROJECTS DIRECTORY}/{TARGET DEVELOPMENT REPOSITORY} --github-issue-url https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1
+  ```
+
+- "Diagnose https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1"
+
+  ```bash
+  # This investigates the reported issue, identifies potential root causes, and requests additional information.
+  askcc diagnose --cwd {PROJECTS DIRECTORY}/{TARGET DEVELOPMENT REPOSITORY} --github-issue-url https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1
   ```
 
 WARNING: If the `{TARGET DEVELOPMENT REPOSITORY}` cannot be determined, ASK user in Slack.

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -47,6 +47,10 @@ EXPECTED_TEMPLATE_FILES = {
     "DEVELOP_USER_PROMPT.md",
     "REVIEW_SYSTEM_PROMPT.md",
     "REVIEW_USER_PROMPT.md",
+    "EXPLORE_SYSTEM_PROMPT.md",
+    "EXPLORE_USER_PROMPT.md",
+    "DIAGNOSE_SYSTEM_PROMPT.md",
+    "DIAGNOSE_USER_PROMPT.md",
 }
 
 
@@ -163,6 +167,24 @@ class TestLoadAgentConfig:
         config = load_agent_config(AgentType.REVIEW)
         assert config.agent_name == "reviewer"
         assert config.description == "Reviews a GitHub issue for clarity, completeness, and feasibility"
+
+    def test_load_explore_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentType.EXPLORE)
+        assert config.agent_name == "explorer"
+        assert config.description == "Investigates a GitHub issue and proposes best-practice solutions"
+
+    def test_load_diagnose_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentType.DIAGNOSE)
+        assert config.agent_name == "diagnostician"
+        assert config.description == "Investigates a reported issue and identifies potential causes"
 
     def test_raises_on_missing_required_variable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         templates_dir = tmp_path / "templates"


### PR DESCRIPTION
## Summary
- Add `explore` command — investigates a GitHub issue, researches the codebase, and proposes best-practice solutions with trade-offs
- Add `diagnose` command — investigates a reported issue, identifies potential root causes, flags unknowns, and requests additional information
- Update SKILL.md with instructions and examples for both commands

## Test plan
- [x] `pytest tests/` passes (21 tests)
- [x] `askcc explore --help` and `askcc diagnose --help` show correct usage
- [ ] Run `askcc explore --github-issue-url <url>` against a real issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)