### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.1"
+version = "0.1.2"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2 in `pyproject.toml` and `uv.lock`

## Test plan
- [x] `uv lock` resolves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)