### PR TITLE
:bug: Fix --version displaying stale version

### DIFF
--- a/askcc/__init__.py
+++ b/askcc/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("askcc")


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "0.1.0"` in `askcc/__init__.py` with `importlib.metadata.version("askcc")`
- Version is now sourced dynamically from package metadata (pyproject.toml), eliminating version drift between the two files

## Test plan
- [ ] Run `askcc --version` and verify it shows `0.1.2`
- [ ] Confirm no import errors on startup