### PR TITLE
:bookmark: Bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.2"
+version = "0.1.3"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump package version from 0.1.2 to 0.1.3 to allow fresh installs to pick up recent fixes

## Test plan
- [ ] Verify `askcc --version` shows `0.1.3` after install