### PR TITLE
Add -g shorthand and -i/--ignore-labels CLI options

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -87,25 +87,32 @@ def main() -> None:
         default=None,
         help="Working directory for the claude subprocess (defaults to current directory).",
     )
+    parser.add_argument(
+        "-i",
+        "--ignore-labels",
+        action="store_true",
+        default=False,
+        help="Bypass issue label verification.",
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     plan_parser = subparsers.add_parser("plan", help="Run Claude in plan mode (read-only analysis).")
-    plan_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to plan.")
+    plan_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to plan.")
 
     develop_parser = subparsers.add_parser("develop", help="Run Claude in development mode.")
-    develop_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to develop.")
+    develop_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to develop.")
 
     review_parser = subparsers.add_parser("review", help="Run Claude in review mode (issue quality review).")
-    review_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to review.")
+    review_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to review.")
 
     explore_parser = subparsers.add_parser(
         "explore", help="Run Claude in explore mode (investigate and propose solutions)."
     )
-    explore_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to explore.")
+    explore_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to explore.")
 
     diagnose_parser = subparsers.add_parser("diagnose", help="Run Claude in diagnose mode (root cause analysis).")
-    diagnose_parser.add_argument("--github-issue-url", required=True, help="GitHub issue URL to diagnose.")
+    diagnose_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to diagnose.")
 
     install_parser = subparsers.add_parser("install", help="Install bundled skills to the agent workspace.")
     install_parser.add_argument(
@@ -123,11 +130,12 @@ def main() -> None:
 
     bootstrap_templates()
 
-    label_errors = validate_issue_labels(args.github_issue_url)
-    if label_errors:
-        for error in label_errors:
-            logger.error(error)
-        sys.exit(1)
+    if not args.ignore_labels:
+        label_errors = validate_issue_labels(args.github_issue_url)
+        if label_errors:
+            for error in label_errors:
+                logger.error(error)
+            sys.exit(1)
 
     agent = AgentType(args.command)
     config = load_agent_config(agent)

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -39,7 +39,8 @@ Do not speculate about code you have not opened.
 Your plan must include:
 1. A summary of the current state — what exists today that relates to the issue.
 2. Step-by-step implementation tasks, each referencing specific files and functions.
-3. Acceptance criteria — concrete, verifiable conditions that confirm the issue is resolved.
+3. Acceptance criteria — concrete, verifiable conditions that confirm the issue is resolved. \
+Provide clear and explicit verification criteria (e.g., commands to run, expected output, or manual steps).
 4. Risks or open questions — flag ambiguities in the issue rather than assuming intent.
 
 When open questions require a decision from the issue author or maintainer before planning can proceed, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.6"
+version = "0.1.8"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.6"
+version = "0.1.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add `-g` as a short option alternative to `--github-issue-url` on all subcommands
- Add `-i/--ignore-labels` flag to bypass issue label verification
- Strengthen plan agent acceptance criteria prompt with explicit verification guidance
- Bump version to 0.1.8

## Test plan
- [ ] Verify `askcc plan -g <url>` works as shorthand for `--github-issue-url`
- [ ] Verify `askcc -i plan -g <url>` bypasses label validation
- [ ] Verify label validation still runs when `-i` is not provided