### PR TITLE
Add language option and file-based logging

### DIFF
--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 DEFAULT_LOG_LEVEL = "INFO"
@@ -14,14 +15,33 @@ REQUIRED_ISSUE_LABEL_PREFIXES: tuple[str, ...] = ("action:",)
 
 ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"
+LOG_DIR: Path = ASKCC_HOME / "logs"
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] (%(name)s) %(funcName)s: %(message)s"
+LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+LOG_BACKUP_COUNT = 3
 
 
 def configure_logging() -> None:
     """Configure logging for the application. Call explicitly from entry points."""
-    logging.basicConfig(
-        stream=sys.stdout,
-        level=getattr(logging, LOG_LEVEL, logging.DEBUG),
-        format="%(asctime)s [%(levelname)s] (%(name)s) %(funcName)s: %(message)s",
+    log_level = getattr(logging, LOG_LEVEL, logging.DEBUG)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(log_level)
+    stdout_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    root_logger.addHandler(stdout_handler)
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    file_handler = RotatingFileHandler(
+        LOG_DIR / "askcc.log",
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
     )
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    root_logger.addHandler(file_handler)
+
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.10"
+version = "0.1.11"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add `--language/-l` CLI option for specifying agent output language (english, japanese)
- Add file-based logging with rotation to `~/.askcc/logs/askcc.log` (5MB max, 3 backups)
- Bump version to 0.1.11

## Test plan
- [x] All 31 existing tests pass
- [ ] Verify `~/.askcc/logs/askcc.log` is created on first run
- [ ] Verify log rotation triggers at 5MB
- [ ] Verify `--language japanese` appends instruction to prompt