### PR TITLE
Auto-detect ~/.claude and ~/.openclaw for skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ askcc install [--directory DIR]
 | `review`   | Fetch the issue and run Claude in review mode (issue quality review)     |
 | `explore`  | Fetch the issue and run Claude in explore mode (investigate and propose solutions) |
 | `diagnose` | Fetch the issue and run Claude in diagnose mode (root cause analysis)    |
-| `install`  | Install bundled skills to the agent workspace                            |
+| `install`  | Install bundled skills to `~/.claude/skills` and/or `~/.openclaw/workspace/skills` |
 
 ### Options
 
@@ -51,7 +51,7 @@ askcc install [--directory DIR]
 |----------------------|----------------------------------------------------------|
 | `--github-issue-url` | **(required)** GitHub issue URL to process               |
 | `--cwd`              | Working directory for the Claude subprocess (default: cwd) |
-| `--directory`        | Target directory for skills (`install` command only)       |
+| `--directory`        | Override auto-detection and install skills to this directory (`install` only) |
 | `--version`          | Show version                                             |
 
 ### Environment Variables
@@ -103,6 +103,19 @@ Develop an issue in a specific project directory:
 ```bash
 askcc --cwd /path/to/project develop --github-issue-url https://github.com/monkut/askcc-cli/issues/1
 ```
+
+Install bundled skills:
+
+```bash
+askcc install
+```
+
+The `install` command auto-detects which agent platforms are available:
+
+- **`~/.claude`** — copies skills to `~/.claude/skills/` (auto-discovered by Claude Code)
+- **`~/.openclaw`** — copies skills to `~/.openclaw/workspace/skills/` and registers them in `openclaw.json`
+
+Both targets are installed if both directories exist. Use `--directory` to override auto-detection and install to a specific path.
 
 ## Project Structure
 

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -126,7 +126,7 @@ def main() -> None:
         "--directory",
         type=Path,
         default=None,
-        help="Target directory for skills (defaults to ~/.openclaw/workspace/skills).",
+        help="Target directory for skills (overrides auto-detection of ~/.claude and ~/.openclaw).",
     )
 
     args = parser.parse_args()

--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -99,16 +99,17 @@ def validate_issue_labels(github_issue_url: str) -> list[str]:
     return errors
 
 
-DEFAULT_SKILLS_DIR = Path.home() / ".openclaw" / "workspace" / "skills"
-OPENCLAW_CONFIG_PATH = Path.home() / ".openclaw" / "openclaw.json"
+CLAUDE_HOME = Path.home() / ".claude"
+CLAUDE_SKILLS_DIR = CLAUDE_HOME / "skills"
+OPENCLAW_HOME = Path.home() / ".openclaw"
+OPENCLAW_SKILLS_DIR = OPENCLAW_HOME / "workspace" / "skills"
+OPENCLAW_CONFIG_PATH = OPENCLAW_HOME / "openclaw.json"
 
 
-def install_skills(directory: Path | None = None) -> None:
-    """Copy bundled skills to the target directory and register them in openclaw.json."""
-    target_dir = directory or DEFAULT_SKILLS_DIR
+def _copy_skills(target_dir: Path) -> list[str]:
+    """Copy bundled skill directories to target_dir. Returns list of installed skill names."""
     skills_source = package_files("askcc") / "skills"
-
-    # Copy each skill directory
+    installed = []
     for skill_dir in sorted(skills_source.iterdir(), key=lambda p: p.name):
         if not skill_dir.is_dir() or skill_dir.name.startswith("__"):
             continue
@@ -117,9 +118,35 @@ def install_skills(directory: Path | None = None) -> None:
             shutil.rmtree(dest)
         shutil.copytree(str(skill_dir), dest)
         logger.info("Installed skill '%s' to %s", skill_dir.name, dest)
+        installed.append(skill_dir.name)
+    return installed
 
-        # Register in openclaw.json
-        _register_skill(skill_dir.name)
+
+def install_skills(directory: Path | None = None) -> None:
+    """Copy bundled skills to detected target directories.
+
+    When --directory is given, install only there.
+    Otherwise auto-detect ~/.claude and ~/.openclaw and install to whichever exist.
+    """
+    if directory:
+        _copy_skills(directory)
+        return
+
+    targets_found = False
+
+    if CLAUDE_HOME.is_dir():
+        targets_found = True
+        CLAUDE_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        _copy_skills(CLAUDE_SKILLS_DIR)
+
+    if OPENCLAW_HOME.is_dir():
+        targets_found = True
+        OPENCLAW_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        for name in _copy_skills(OPENCLAW_SKILLS_DIR):
+            _register_skill(name)
+
+    if not targets_found:
+        logger.warning("No target directories found (~/.claude or ~/.openclaw). Skipping skill installation.")
 
 
 def _register_skill(skill_name: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.11"
+version = "0.1.12"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -17,6 +17,7 @@ from askcc.functions import (
     _parse_issue_url,
     append_usage_to_last_comment,
     bootstrap_templates,
+    install_skills,
     load_agent_config,
     load_template,
     validate_template,
@@ -365,3 +366,75 @@ class TestLanguageOption:
     def test_default_no_append(self):
         prompt = self._run_main([])
         assert "Output all comments in" not in prompt
+
+
+class TestInstallSkills:
+    def test_explicit_directory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        target = tmp_path / "custom-skills"
+        target.mkdir()
+        install_skills(directory=target)
+
+        installed = [d.name for d in target.iterdir() if d.is_dir()]
+        assert "request-askcc" in installed
+
+    def test_auto_detect_claude_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        claude_home = tmp_path / ".claude"
+        claude_home.mkdir()
+        monkeypatch.setattr("askcc.functions.CLAUDE_HOME", claude_home)
+        monkeypatch.setattr("askcc.functions.CLAUDE_SKILLS_DIR", claude_home / "skills")
+        monkeypatch.setattr("askcc.functions.OPENCLAW_HOME", tmp_path / ".openclaw")
+
+        install_skills()
+
+        installed = [d.name for d in (claude_home / "skills").iterdir() if d.is_dir()]
+        assert "request-askcc" in installed
+
+    def test_auto_detect_openclaw_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        openclaw_home = tmp_path / ".openclaw"
+        openclaw_home.mkdir()
+        config_path = openclaw_home / "openclaw.json"
+        config_path.write_text("{}")
+        skills_dir = openclaw_home / "workspace" / "skills"
+
+        monkeypatch.setattr("askcc.functions.CLAUDE_HOME", tmp_path / ".claude")
+        monkeypatch.setattr("askcc.functions.OPENCLAW_HOME", openclaw_home)
+        monkeypatch.setattr("askcc.functions.OPENCLAW_SKILLS_DIR", skills_dir)
+        monkeypatch.setattr("askcc.functions.OPENCLAW_CONFIG_PATH", config_path)
+
+        install_skills()
+
+        installed = [d.name for d in skills_dir.iterdir() if d.is_dir()]
+        assert "request-askcc" in installed
+        config = json.loads(config_path.read_text())
+        assert config["skills"]["entries"]["request-askcc"]["enabled"] is True
+
+    def test_auto_detect_both(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        claude_home = tmp_path / ".claude"
+        claude_home.mkdir()
+        openclaw_home = tmp_path / ".openclaw"
+        openclaw_home.mkdir()
+        config_path = openclaw_home / "openclaw.json"
+        config_path.write_text("{}")
+        skills_dir = openclaw_home / "workspace" / "skills"
+
+        monkeypatch.setattr("askcc.functions.CLAUDE_HOME", claude_home)
+        monkeypatch.setattr("askcc.functions.CLAUDE_SKILLS_DIR", claude_home / "skills")
+        monkeypatch.setattr("askcc.functions.OPENCLAW_HOME", openclaw_home)
+        monkeypatch.setattr("askcc.functions.OPENCLAW_SKILLS_DIR", skills_dir)
+        monkeypatch.setattr("askcc.functions.OPENCLAW_CONFIG_PATH", config_path)
+
+        install_skills()
+
+        assert (claude_home / "skills" / "request-askcc").is_dir()
+        assert (skills_dir / "request-askcc").is_dir()
+
+    def test_auto_detect_neither(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setattr("askcc.functions.CLAUDE_HOME", tmp_path / ".claude")
+        monkeypatch.setattr("askcc.functions.OPENCLAW_HOME", tmp_path / ".openclaw")
+
+        with caplog.at_level("WARNING", logger="askcc.functions"):
+            install_skills()
+
+        assert "No target directories found" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- `askcc install` now auto-detects `~/.claude` and `~/.openclaw` directories and installs bundled skills to whichever exist
- `~/.claude/skills/` targets are copied directly (auto-discovered by Claude Code)
- `~/.openclaw/workspace/skills/` targets are copied and registered in `openclaw.json`
- `--directory` flag overrides auto-detection for backward compatibility
- Version bumped to 0.1.12

## Test plan

- [x] 36 tests pass (5 new for install_skills auto-detection)
- [x] Lint passes (`uv run poe check`)