### PR TITLE
Include issue URL in action log message

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_PERMISSION_MODE = "acceptEdits"
 
 
-def _run_claude(prompt: str, config: AgentConfig, *, cwd: Path | None = None) -> tuple[int, dict | None]:
+def _run_claude(
+    prompt: str, config: AgentConfig, *, issue_url: str, cwd: Path | None = None
+) -> tuple[int, dict | None]:
     """Run claude CLI with the given prompt, capturing JSON output for token usage reporting."""
     agent_definition = {config.action_name: {"description": config.description, "prompt": config.system_prompt}}
 
@@ -38,7 +40,7 @@ def _run_claude(prompt: str, config: AgentConfig, *, cwd: Path | None = None) ->
         json.dumps(agent_definition),
     ]
 
-    logger.info("Requesting '%s' action from Claude Code ...", config.action_name)
+    logger.info("Requesting '%s' action for %s from Claude Code ...", config.action_name, issue_url)
     result = subprocess.run(  # noqa: S603
         cmd,
         text=True,
@@ -151,7 +153,7 @@ def main() -> None:
     if args.language != SupportedLanguage.ENGLISH:
         prompt += f"\nOutput all comments in {args.language}."
     logger.info("Prompt prepared for '%s' command", agent.value)
-    return_code, usage = _run_claude(prompt, config=config, cwd=args.cwd)
+    return_code, usage = _run_claude(prompt, config=config, issue_url=args.github_issue_url, cwd=args.cwd)
 
     if usage:
         append_usage_to_last_comment(args.github_issue_url, usage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.13"
+version = "0.1.14"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -245,7 +245,9 @@ class TestRunClaude:
             caplog.at_level("INFO", logger="askcc.cli"),
             patch("askcc.cli.subprocess.run", return_value=mock_result) as mock_run,
         ):
-            exit_code, usage = _run_claude("test prompt", config=agent_config)
+            exit_code, usage = _run_claude(
+                "test prompt", config=agent_config, issue_url="https://github.com/test/repo/issues/1"
+            )
 
         assert exit_code == 0
         assert usage == {"input_tokens": 1500, "output_tokens": 300}
@@ -261,7 +263,9 @@ class TestRunClaude:
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
 
         with patch("askcc.cli.subprocess.run", return_value=mock_result):
-            exit_code, usage = _run_claude("test prompt", config=agent_config)
+            exit_code, usage = _run_claude(
+                "test prompt", config=agent_config, issue_url="https://github.com/test/repo/issues/1"
+            )
 
         assert exit_code == 0
         assert usage is None
@@ -273,7 +277,9 @@ class TestRunClaude:
         mock_result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="error occurred")
 
         with patch("askcc.cli.subprocess.run", return_value=mock_result):
-            exit_code, usage = _run_claude("test prompt", config=agent_config)
+            exit_code, usage = _run_claude(
+                "test prompt", config=agent_config, issue_url="https://github.com/test/repo/issues/1"
+            )
 
         assert exit_code == 1
         assert usage is None
@@ -283,7 +289,9 @@ class TestRunClaude:
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
 
         with patch("askcc.cli.subprocess.run", return_value=mock_result):
-            exit_code, usage = _run_claude("test prompt", config=agent_config)
+            exit_code, usage = _run_claude(
+                "test prompt", config=agent_config, issue_url="https://github.com/test/repo/issues/1"
+            )
 
         assert exit_code == 0
         assert usage is None


### PR DESCRIPTION
## Summary
- Add issue URL to the `_run_claude` log message for better traceability: `Requesting '<action>' action for <issue_url> from Claude Code ...`
- Bump version to 0.1.14

## Test plan
- [x] All existing tests updated and passing