### PR TITLE
Log stderr via logger instead of print

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -69,7 +69,10 @@ def _run_claude(
             print(result.stdout)  # noqa: T201
 
     if result.stderr:
-        print(result.stderr, file=sys.stderr)  # noqa: T201
+        if result.returncode != 0:
+            logger.error("Claude Code stderr:\n%s", result.stderr)
+        else:
+            logger.warning("Claude Code stderr:\n%s", result.stderr)
 
     return result.returncode, usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.14"
+version = "0.1.15"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.13"
+version = "0.1.15"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Route `claude` subprocess stderr through `logger.error()` on non-zero exit and `logger.warning()` on success, replacing direct `print` to stderr
- Bump version to 0.1.15

## Test plan
- [x] All 36 existing tests passing