### PR TITLE
Add review-pr action for automated PR code review

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -12,6 +12,7 @@ from .functions import (
     append_usage_to_last_comment,
     bootstrap_templates,
     fetch_github_issue,
+    fetch_github_pr,
     install_skills,
     load_agent_config,
     validate_issue_labels,
@@ -126,6 +127,9 @@ def main() -> None:
     diagnose_parser = subparsers.add_parser("diagnose", help="Run Claude in diagnose mode (root cause analysis).")
     diagnose_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to diagnose.")
 
+    review_pr_parser = subparsers.add_parser("review-pr", help="Run Claude in PR review mode (automated code review).")
+    review_pr_parser.add_argument("-g", "--github-pr-url", required=True, help="GitHub PR URL to review.")
+
     install_parser = subparsers.add_parser("install", help="Install bundled skills to the agent workspace.")
     install_parser.add_argument(
         "--directory",
@@ -142,24 +146,31 @@ def main() -> None:
 
     bootstrap_templates()
 
-    if not args.ignore_labels:
-        label_errors = validate_issue_labels(args.github_issue_url)
-        if label_errors:
-            for error in label_errors:
-                logger.error(error)
-            sys.exit(1)
-
     agent = AgentAction(args.command)
     config = load_agent_config(agent)
-    issue_content = fetch_github_issue(args.github_issue_url)
-    prompt = Template(config.user_prompt_template).safe_substitute(issue_content=issue_content)
+
+    if agent == AgentAction.REVIEW_PR:
+        pr_content = fetch_github_pr(args.github_pr_url)
+        prompt = Template(config.user_prompt_template).safe_substitute(pr_content=pr_content)
+        target_url = args.github_pr_url
+    else:
+        if not args.ignore_labels:
+            label_errors = validate_issue_labels(args.github_issue_url)
+            if label_errors:
+                for error in label_errors:
+                    logger.error(error)
+                sys.exit(1)
+        issue_content = fetch_github_issue(args.github_issue_url)
+        prompt = Template(config.user_prompt_template).safe_substitute(issue_content=issue_content)
+        target_url = args.github_issue_url
+
     if args.language != SupportedLanguage.ENGLISH:
         prompt += f"\nOutput all comments in {args.language}."
     logger.info("Prompt prepared for '%s' command", agent.value)
-    return_code, usage = _run_claude(prompt, config=config, issue_url=args.github_issue_url, cwd=args.cwd)
+    return_code, usage = _run_claude(prompt, config=config, issue_url=target_url, cwd=args.cwd)
 
     if usage:
-        append_usage_to_last_comment(args.github_issue_url, usage)
+        append_usage_to_last_comment(target_url, usage)
 
     sys.exit(return_code)
 

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -195,6 +195,48 @@ DIAGNOSE_USER_PROMPT_TEMPLATE = (
     "\n\n$issue_content"
 )
 
+REVIEW_PR_AGENT_PROMPT = """\
+You are an expert code reviewer operating inside Claude Code with access to the filesystem, git, and the gh CLI.
+
+Goal: Review the given GitHub pull request for code quality, correctness, and adherence to project standards, \
+then post actionable feedback as a PR review.
+
+Before reviewing, read the project's conventions, existing tests, and configuration to understand the standards. \
+Do not speculate about code you have not opened.
+
+Steps:
+1. Fetch the PR diff using `gh pr diff <number>`.
+2. Check out the PR branch locally using `gh pr checkout <number>`.
+3. Read each changed file in full to understand context beyond the diff.
+4. Run the project's test suite if a test runner is configured.
+
+Evaluate the PR against these criteria:
+1. **Correctness** — Does the code do what the PR description claims? Are there logic errors or edge cases?
+2. **Tests** — Are new or changed behaviors covered by tests? Do existing tests still pass?
+3. **Style & conventions** — Does the code follow the project's established patterns and linting rules?
+4. **Security** — Are there potential vulnerabilities (injection, auth bypass, secrets exposure)?
+5. **Performance** — Are there obvious inefficiencies or regressions?
+6. **Documentation** — Are public APIs, config changes, or behavioral changes documented?
+
+Your review must:
+- Start with a one-paragraph summary of what the PR does and your overall assessment.
+- List specific findings organized by file, each with line references and a concrete suggestion.
+- Distinguish between blocking issues ("must fix") and suggestions ("consider").
+- End with a clear verdict: "Approve", "Request changes", or "Comment only".
+
+Post your review using `gh pr review <number>` with the appropriate flag \
+(--approve, --request-changes, or --comment) and --body containing your full review.
+
+IMPORTANT: You MUST post your review on the GitHub PR using the gh CLI. \
+Do NOT skip this step — the review is the primary deliverable of this task.
+"""
+
+REVIEW_PR_USER_PROMPT_TEMPLATE = (
+    "Review the following GitHub pull request for code quality, correctness, and adherence to project standards."
+    " You MUST post your review on the GitHub PR using the gh CLI."
+    "\n\n$pr_content"
+)
+
 REVIEW_USER_PROMPT_TEMPLATE = (
     "Review the following GitHub issue for clarity, completeness, and feasibility."
     " You MUST post your complete review as a comment on the GitHub issue using the gh CLI."
@@ -234,6 +276,7 @@ class AgentAction(StrEnum):
     PLAN = "plan"
     DEVELOP = "develop"
     REVIEW = "review"
+    REVIEW_PR = "review-pr"
     EXPLORE = "explore"
     DIAGNOSE = "diagnose"
 
@@ -283,5 +326,14 @@ AGENT_CONFIGS: dict[AgentAction, AgentConfig] = {
         system_prompt_file="DIAGNOSE_SYSTEM_PROMPT.md",
         user_prompt_file="DIAGNOSE_USER_PROMPT.md",
         required_variables=("issue_content",),
+    ),
+    AgentAction.REVIEW_PR: AgentConfig(
+        action_name="review-pr",
+        description="Reviews a GitHub pull request for code quality and correctness",
+        system_prompt=REVIEW_PR_AGENT_PROMPT,
+        user_prompt_template=REVIEW_PR_USER_PROMPT_TEMPLATE,
+        system_prompt_file="REVIEW_PR_SYSTEM_PROMPT.md",
+        user_prompt_file="REVIEW_PR_USER_PROMPT.md",
+        required_variables=("pr_content",),
     ),
 }

--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -13,20 +13,33 @@ from .settings import ENABLE_ISSUE_LABEL_PREFIX_VALIDATION, REQUIRED_ISSUE_LABEL
 
 logger = logging.getLogger(__name__)
 
-MIN_ISSUE_URL_PARTS = 4
+MIN_URL_PARTS = 4
 
 
 def _parse_issue_url(github_issue_url: str) -> tuple[str, str, int]:
     """Parse a GitHub issue URL into (owner, repo, issue_number)."""
     parsed = urlparse(github_issue_url)
     parts = parsed.path.strip("/").split("/")
-    if len(parts) < MIN_ISSUE_URL_PARTS or parts[2] != "issues":
+    if len(parts) < MIN_URL_PARTS or parts[2] != "issues":
         msg = f"Invalid GitHub issue URL: {github_issue_url}"
         raise ValueError(msg)
     owner = parts[0]
     repo = parts[1]
     issue_number = int(parts[3])
     return owner, repo, issue_number
+
+
+def _parse_pr_url(github_pr_url: str) -> tuple[str, str, int]:
+    """Parse a GitHub pull request URL into (owner, repo, pr_number)."""
+    parsed = urlparse(github_pr_url)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) < MIN_URL_PARTS or parts[2] != "pull":
+        msg = f"Invalid GitHub PR URL: {github_pr_url}"
+        raise ValueError(msg)
+    owner = parts[0]
+    repo = parts[1]
+    pr_number = int(parts[3])
+    return owner, repo, pr_number
 
 
 def _require_gh_cli() -> str:
@@ -68,6 +81,47 @@ def fetch_github_issue(github_issue_url: str) -> str:
     if comment_texts:
         sections.append("Comments:\n" + "\n---\n".join(comment_texts))
     logger.info("Fetched issue with %d comment(s)", len(comment_texts))
+
+    return "\n\n".join(sections)
+
+
+def fetch_github_pr(github_pr_url: str) -> str:
+    """Fetch a GitHub PR description, metadata, and review comments, combined into a single string."""
+    gh = _require_gh_cli()
+    owner, repo, pr_number = _parse_pr_url(github_pr_url)
+    repo_nwo = f"{owner}/{repo}"
+    logger.info("Fetching PR #%d from %s ...", pr_number, repo_nwo)
+
+    pr_result = subprocess.run(  # noqa: S603
+        [
+            gh,
+            "api",
+            f"repos/{repo_nwo}/pulls/{pr_number}",
+            "--jq",
+            ".title, .body, .head.ref, .base.ref",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pr_text = pr_result.stdout.strip()
+
+    logger.info("Fetching review comments for PR #%d ...", pr_number)
+    comments_result = subprocess.run(  # noqa: S603
+        [gh, "api", "--paginate", f"repos/{repo_nwo}/pulls/{pr_number}/comments"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    comments_data = json.loads(comments_result.stdout)
+    comment_texts = [
+        f"Review comment by @{c['user']['login']} on {c.get('path', '')}:\n{c['body']}" for c in comments_data
+    ]
+
+    sections = [f"PR URL: {github_pr_url}\n\nPR #{pr_number}:\n{pr_text}"]
+    if comment_texts:
+        sections.append("Review Comments:\n" + "\n---\n".join(comment_texts))
+    logger.info("Fetched PR with %d review comment(s)", len(comment_texts))
 
     return "\n\n".join(sections)
 

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -15,6 +15,7 @@ from askcc.cli import _run_claude, main
 from askcc.definitions import AGENT_CONFIGS, AgentAction, AgentConfig, SupportedLanguage
 from askcc.functions import (
     _parse_issue_url,
+    _parse_pr_url,
     append_usage_to_last_comment,
     bootstrap_templates,
     install_skills,
@@ -46,6 +47,28 @@ class TestParseIssueUrl:
         assert issue_number == 7
 
 
+class TestParsePrUrl:
+    def test_valid_pr_url(self):
+        owner, repo, pr_number = _parse_pr_url("https://github.com/monkut/askcc-cli/pull/5")
+        assert owner == "monkut"
+        assert repo == "askcc-cli"
+        assert pr_number == 5
+
+    def test_invalid_url_missing_pull_segment(self):
+        with pytest.raises(ValueError):
+            _parse_pr_url("https://github.com/monkut/askcc-cli/issues/1")
+
+    def test_invalid_url_too_few_parts(self):
+        with pytest.raises(ValueError):
+            _parse_pr_url("https://github.com/monkut")
+
+    def test_valid_url_with_trailing_slash(self):
+        owner, repo, pr_number = _parse_pr_url("https://github.com/monkut/askcc-cli/pull/10/")
+        assert owner == "monkut"
+        assert repo == "askcc-cli"
+        assert pr_number == 10
+
+
 EXPECTED_TEMPLATE_FILES = {
     "PLAN_SYSTEM_PROMPT.md",
     "PLAN_USER_PROMPT.md",
@@ -53,6 +76,8 @@ EXPECTED_TEMPLATE_FILES = {
     "DEVELOP_USER_PROMPT.md",
     "REVIEW_SYSTEM_PROMPT.md",
     "REVIEW_USER_PROMPT.md",
+    "REVIEW_PR_SYSTEM_PROMPT.md",
+    "REVIEW_PR_USER_PROMPT.md",
     "EXPLORE_SYSTEM_PROMPT.md",
     "EXPLORE_USER_PROMPT.md",
     "DIAGNOSE_SYSTEM_PROMPT.md",
@@ -191,6 +216,16 @@ class TestLoadAgentConfig:
         config = load_agent_config(AgentAction.DIAGNOSE)
         assert config.action_name == "diagnose"
         assert config.description == "Investigates a reported issue and identifies potential causes"
+
+    def test_load_review_pr_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentAction.REVIEW_PR)
+        assert config.action_name == "review-pr"
+        assert config.description == "Reviews a GitHub pull request for code quality and correctness"
+        assert config.required_variables == ("pr_content",)
 
     def test_raises_on_missing_required_variable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         templates_dir = tmp_path / "templates"
@@ -345,6 +380,50 @@ class TestAppendUsageToLastComment:
         body_arg = patch_call[0][0][-1]
         expected = f"body={original_body}\n\n:tokens-used: input: 200, output: 100"
         assert body_arg == expected
+
+
+class TestReviewPrCommand:
+    PR_URL = "https://github.com/monkut/askcc-cli/pull/5"
+
+    def test_review_pr_calls_fetch_github_pr(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.fetch_github_pr", return_value="pr body") as mock_fetch_pr,
+            patch("askcc.cli._run_claude", return_value=(0, None)) as mock_claude,
+            patch("sys.argv", ["askcc", "review-pr", "-g", self.PR_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_fetch_pr.assert_called_once_with(self.PR_URL)
+        prompt = mock_claude.call_args[0][0]
+        assert "pr body" in prompt
+
+    def test_review_pr_skips_label_validation(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.fetch_github_pr", return_value="pr body"),
+            patch("askcc.cli.validate_issue_labels") as mock_validate,
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("sys.argv", ["askcc", "review-pr", "-g", self.PR_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_validate.assert_not_called()
+
+    def test_review_pr_with_language(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.fetch_github_pr", return_value="pr body"),
+            patch("askcc.cli._run_claude", return_value=(0, None)) as mock_claude,
+            patch("sys.argv", ["askcc", "--language", "japanese", "review-pr", "-g", self.PR_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        prompt = mock_claude.call_args[0][0]
+        assert prompt.endswith("\nOutput all comments in japanese.")
 
 
 class TestLanguageOption:


### PR DESCRIPTION
## Summary

- Adds a new `review-pr` subcommand that accepts a GitHub PR URL (`--github-pr-url`) and performs automated code review
- Reviews PRs for correctness, tests, style/conventions, security, performance, and documentation
- Posts review feedback directly on the PR via `gh pr review` with approve/request-changes/comment verdicts
- Skips issue label validation since PRs are not issues

## Changes

- **askcc/definitions.py**: `REVIEW_PR_AGENT_PROMPT`, `REVIEW_PR_USER_PROMPT_TEMPLATE`, `AgentAction.REVIEW_PR` enum value, `AGENT_CONFIGS` entry with `pr_content` template variable
- **askcc/functions.py**: `_parse_pr_url()` for PR URL parsing, `fetch_github_pr()` for fetching PR metadata and review comments
- **askcc/cli.py**: `review-pr` subparser with `--github-pr-url` argument, PR-specific flow that bypasses issue label validation
- **tests/test_askcc.py**: `TestParsePrUrl` (4 tests), `TestReviewPrCommand` (3 tests), `TestLoadAgentConfig.test_load_review_pr_config`, updated `EXPECTED_TEMPLATE_FILES`

## Test plan

- [x] All 44 tests pass (`uv run pytest -v tests/`)
- [x] `ruff check` and `ruff format` clean
- [ ] Manual test: `askcc review-pr -g https://github.com/owner/repo/pull/N`