### PR TITLE
:bug: Fix skill install and improve usage reporting

### DIFF
--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -129,24 +129,21 @@ def install_skills(directory: Path | None = None) -> None:
     Otherwise auto-detect ~/.claude and ~/.openclaw and install to whichever exist.
     """
     if directory:
-        _copy_skills(directory)
+        _copy_skills(directory.expanduser())
         return
 
-    targets_found = False
-
     if CLAUDE_HOME.is_dir():
-        targets_found = True
         CLAUDE_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
         _copy_skills(CLAUDE_SKILLS_DIR)
+    else:
+        logger.warning("Target directory not found: %s. Skipping skill installation.", CLAUDE_HOME)
 
     if OPENCLAW_HOME.is_dir():
-        targets_found = True
         OPENCLAW_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
         for name in _copy_skills(OPENCLAW_SKILLS_DIR):
             _register_skill(name)
-
-    if not targets_found:
-        logger.warning("No target directories found (~/.claude or ~/.openclaw). Skipping skill installation.")
+    else:
+        logger.warning("Target directory not found: %s. Skipping skill installation.", OPENCLAW_HOME)
 
 
 def _register_skill(skill_name: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.16"
+version = "0.1.17"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Call `expanduser()` on `--directory` argument to resolve literal `~` paths
- Log missing target directories individually with fully resolved paths
- Include model name in token usage logs and GitHub issue comments
- Run claude subprocess in isolated `--worktree` for safety
- Bump version to 0.1.17

## Test plan
- [ ] Run `askcc install` without `~/.claude` or `~/.openclaw` and verify separate warning per directory with resolved paths
- [ ] Run `askcc install --directory ~/.claude/skills` and verify `expanduser()` resolves correctly
- [ ] Verify `:tokens-used:` comment includes model name
- [ ] Verify claude subprocess runs in a worktree