### PR TITLE
:bug: Unset CLAUDECODE env var for child claude subprocess

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -41,6 +42,9 @@ def _run_claude(
         json.dumps(agent_definition),
     ]
 
+    # Remove CLAUDECODE env var so the child claude process doesn't think it's nested inside Claude Code
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
     logger.info("Requesting '%s' action for %s from Claude Code ...", config.action_name, issue_url)
     result = subprocess.run(  # noqa: S603
         cmd,
@@ -48,6 +52,7 @@ def _run_claude(
         check=False,
         capture_output=True,
         cwd=cwd,
+        env=env,
     )
     logger.info("Claude Code finished %s (exit code: %d)", issue_url, result.returncode)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.18"
+version = "0.1.19"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Remove `CLAUDECODE` environment variable when spawning child `claude` subprocess to prevent it from detecting a nested Claude Code session
- Bump version to 0.1.19

## Test plan
- [ ] Run `askcc plan -g <issue-url>` from within a Claude Code session and verify the child process executes normally
- [ ] Verify `CLAUDECODE` is not present in the child process environment