### PR TITLE
Add label/project transition to develop command

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -16,6 +16,7 @@ from .functions import (
     fetch_github_issue,
     install_skills,
     load_agent_config,
+    transition_issue_to_review,
     validate_issue_labels,
     validate_issue_readiness,
 )
@@ -204,6 +205,9 @@ def main() -> None:  # noqa: PLR0915
 
     if usage:
         append_usage_to_last_comment(args.github_issue_url, usage)
+
+    if args.command == "develop" and return_code == 0:
+        transition_issue_to_review(args.github_issue_url)
 
     sys.exit(return_code)
 

--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -12,8 +12,13 @@ from urllib.parse import urlparse
 from .definitions import AGENT_CONFIGS, AgentAction, AgentConfig
 from .settings import (
     BLOCKING_LABELS,
+    DEVELOP_LABEL,
     ENABLE_ISSUE_LABEL_PREFIX_VALIDATION,
     REQUIRED_ISSUE_LABEL_PREFIXES,
+    REVIEW_LABEL,
+    REVIEW_STATUS_OPTIONS,
+    REVIEWER_FIELD_NAME,
+    REVIEWER_FIELD_VALUE,
     TEMPLATES_DIR,
 )
 
@@ -334,6 +339,201 @@ def append_usage_to_last_comment(github_issue_url: str, usage: dict) -> None:
         check=True,
     )
     logger.info("Appended token usage to comment %d on issue #%d", comment_id, issue_number)
+
+
+def _swap_issue_labels(gh: str, repo_nwo: str, issue_number: int, *, remove: str, add: str) -> None:
+    """Remove one label and add another on a GitHub issue. Warns on failure."""
+    try:
+        subprocess.run(  # noqa: S603
+            [gh, "issue", "edit", str(issue_number), "-R", repo_nwo, "--remove-label", remove, "--add-label", add],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Transitioned labels: -%s +%s on issue #%d", remove, add, issue_number)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Failed to transition labels on issue #%d: %s", issue_number, exc.stderr)
+
+
+def _find_option_id(options: list[dict], target_names: tuple[str, ...]) -> str | None:
+    """Find the first matching option ID from a list of single-select options (case-insensitive)."""
+    lower_targets = {n.lower() for n in target_names}
+    for option in options:
+        if option.get("name", "").lower() in lower_targets:
+            return option["id"]
+    return None
+
+
+_PROJECT_ITEMS_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project {
+            id
+            title
+            statusField: field(name: "Status") {
+              ... on ProjectV2SingleSelectField {
+                id
+                options { id name }
+              }
+            }
+            actionField: field(name: "Needs Action From") {
+              ... on ProjectV2SingleSelectField {
+                id
+                options { id name }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_UPDATE_FIELD_MUTATION = """
+mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: { singleSelectOptionId: $optionId }
+  }) {
+    projectV2Item { id }
+  }
+}
+"""
+
+
+def _update_project_field(
+    gh: str,
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+    *,
+    issue_number: int,
+    project_title: str,
+    field_name: str,
+) -> None:
+    """Update a single-select field on a project item. Warns on failure."""
+    try:
+        subprocess.run(  # noqa: S603
+            [
+                gh,
+                "api",
+                "graphql",
+                "-f",
+                f"query={_UPDATE_FIELD_MUTATION}",
+                "-F",
+                f"projectId={project_id}",
+                "-F",
+                f"itemId={item_id}",
+                "-F",
+                f"fieldId={field_id}",
+                "-F",
+                f"optionId={option_id}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Updated '%s' in project '%s' for issue #%d", field_name, project_title, issue_number)
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Failed to update '%s' in project '%s' for issue #%d: %s",
+            field_name,
+            project_title,
+            issue_number,
+            exc.stderr,
+        )
+
+
+def _transition_project_fields(gh: str, owner: str, repo: str, issue_number: int) -> None:
+    """Move issue to review status in project boards. Best-effort, warns on failure."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                gh,
+                "api",
+                "graphql",
+                "-f",
+                f"query={_PROJECT_ITEMS_QUERY}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"repo={repo}",
+                "-F",
+                f"number={issue_number}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Failed to query project items for issue #%d: %s", issue_number, exc.stderr)
+        return
+
+    data = json.loads(result.stdout)
+    items = data.get("data", {}).get("repository", {}).get("issue", {}).get("projectItems", {}).get("nodes") or []
+
+    if not items:
+        logger.info("Issue #%d is not in any project, skipping project transitions", issue_number)
+        return
+
+    for item in items:
+        project = item.get("project", {})
+        project_id = project.get("id")
+        item_id = item.get("id")
+        project_title = project.get("title", "unknown")
+
+        # Update Status field
+        status_field = project.get("statusField")
+        if status_field and status_field.get("options"):
+            option_id = _find_option_id(status_field["options"], REVIEW_STATUS_OPTIONS)
+            if option_id:
+                _update_project_field(
+                    gh,
+                    project_id,
+                    item_id,
+                    status_field["id"],
+                    option_id,
+                    issue_number=issue_number,
+                    project_title=project_title,
+                    field_name="Status",
+                )
+
+        # Update Needs Action From field
+        action_field = project.get("actionField")
+        if action_field and action_field.get("options"):
+            option_id = _find_option_id(action_field["options"], (REVIEWER_FIELD_VALUE,))
+            if option_id:
+                _update_project_field(
+                    gh,
+                    project_id,
+                    item_id,
+                    action_field["id"],
+                    option_id,
+                    issue_number=issue_number,
+                    project_title=project_title,
+                    field_name=REVIEWER_FIELD_NAME,
+                )
+
+
+def transition_issue_to_review(github_issue_url: str) -> None:
+    """Transition issue labels and project state after successful PR creation.
+
+    All failures are logged as warnings, never raised.
+    """
+    gh = _require_gh_cli()
+    owner, repo, issue_number = _parse_issue_url(github_issue_url)
+    repo_nwo = f"{owner}/{repo}"
+
+    _swap_issue_labels(gh, repo_nwo, issue_number, remove=DEVELOP_LABEL, add=REVIEW_LABEL)
+    _transition_project_fields(gh, owner, repo, issue_number)
 
 
 def load_agent_config(agent: AgentAction) -> AgentConfig:

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -14,6 +14,15 @@ BLOCKING_LABELS: tuple[str, ...] = (DECISION_ISSUE_LABEL, "blocked")
 ENABLE_ISSUE_LABEL_PREFIX_VALIDATION: bool = os.getenv("ENABLE_ISSUE_LABEL_PREFIX_VALIDATION", "true").lower() == "true"
 REQUIRED_ISSUE_LABEL_PREFIXES: tuple[str, ...] = ("action:",)
 
+# Label transition
+DEVELOP_LABEL = "action:develop"
+REVIEW_LABEL = "action:review"
+
+# Project field transition
+REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
+REVIEWER_FIELD_NAME = "Needs Action From"
+REVIEWER_FIELD_VALUE = "REVIEWER"
+
 ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"
 LOG_DIR: Path = ASKCC_HOME / "logs"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -14,14 +14,18 @@ if TYPE_CHECKING:
 from askcc.cli import _run_claude, main
 from askcc.definitions import AGENT_CONFIGS, AgentAction, AgentConfig, SupportedLanguage
 from askcc.functions import (
+    _find_option_id,
     _has_acceptance_criteria,
     _has_dependencies_section,
     _parse_issue_url,
+    _swap_issue_labels,
+    _transition_project_fields,
     append_usage_to_last_comment,
     bootstrap_templates,
     install_skills,
     load_agent_config,
     load_template,
+    transition_issue_to_review,
     validate_issue_readiness,
     validate_template,
 )
@@ -664,9 +668,239 @@ class TestDevelopSkipValidation:
             patch("askcc.cli.validate_issue_readiness") as mock_validate,
             patch("askcc.cli.fetch_github_issue", return_value="issue body"),
             patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_review"),
             patch("sys.argv", ["askcc", "develop", "--skip-validation", "-g", self.ISSUE_URL]),
             pytest.raises(SystemExit),
         ):
             main()
 
         mock_validate.assert_not_called()
+
+
+class TestFindOptionId:
+    def test_finds_matching_option(self):
+        options = [{"id": "opt1", "name": "Todo"}, {"id": "opt2", "name": "in-review"}]
+        assert _find_option_id(options, ("in-internal-review", "in-review")) == "opt2"
+
+    def test_case_insensitive(self):
+        options = [{"id": "opt1", "name": "In-Review"}]
+        assert _find_option_id(options, ("in-review",)) == "opt1"
+
+    def test_returns_first_match(self):
+        options = [
+            {"id": "opt1", "name": "in-internal-review"},
+            {"id": "opt2", "name": "in-review"},
+        ]
+        assert _find_option_id(options, ("in-internal-review", "in-review")) == "opt1"
+
+    def test_no_match_returns_none(self):
+        options = [{"id": "opt1", "name": "Todo"}, {"id": "opt2", "name": "Done"}]
+        assert _find_option_id(options, ("in-review",)) is None
+
+    def test_empty_options(self):
+        assert _find_option_id([], ("in-review",)) is None
+
+
+class TestSwapIssueLabels:
+    def test_success(self, caplog: pytest.LogCaptureFixture):
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            caplog.at_level("INFO", logger="askcc.functions"),
+            patch("askcc.functions.subprocess.run", return_value=ok) as mock_run,
+        ):
+            _swap_issue_labels("/usr/bin/gh", "owner/repo", 42, remove="action:develop", add="action:review")
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "--remove-label" in cmd
+        assert "--add-label" in cmd
+        assert "Transitioned labels" in caplog.text
+
+    def test_failure_warns(self, caplog: pytest.LogCaptureFixture):
+        with (
+            caplog.at_level("WARNING", logger="askcc.functions"),
+            patch(
+                "askcc.functions.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="label not found"),
+            ),
+        ):
+            _swap_issue_labels("/usr/bin/gh", "owner/repo", 42, remove="action:develop", add="action:review")
+
+        assert "Failed to transition labels" in caplog.text
+
+
+class TestTransitionProjectFields:
+    def _graphql_response(self, nodes: list[dict]) -> str:
+        return json.dumps({"data": {"repository": {"issue": {"projectItems": {"nodes": nodes}}}}})
+
+    def test_no_project_items(self, caplog: pytest.LogCaptureFixture):
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=self._graphql_response([]), stderr="")
+        with (
+            caplog.at_level("INFO", logger="askcc.functions"),
+            patch("askcc.functions.subprocess.run", return_value=result),
+        ):
+            _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
+
+        assert "not in any project" in caplog.text
+
+    def test_updates_status_and_action_fields(self, caplog: pytest.LogCaptureFixture):
+        nodes = [
+            {
+                "id": "item-1",
+                "project": {
+                    "id": "proj-1",
+                    "title": "My Board",
+                    "statusField": {
+                        "id": "field-status",
+                        "options": [
+                            {"id": "opt-todo", "name": "Todo"},
+                            {"id": "opt-review", "name": "in-review"},
+                        ],
+                    },
+                    "actionField": {
+                        "id": "field-action",
+                        "options": [
+                            {"id": "opt-dev", "name": "DEVELOPER"},
+                            {"id": "opt-rev", "name": "REVIEWER"},
+                        ],
+                    },
+                },
+            }
+        ]
+        query_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=self._graphql_response(nodes), stderr=""
+        )
+        mutation_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+
+        with (
+            caplog.at_level("INFO", logger="askcc.functions"),
+            patch("askcc.functions.subprocess.run", side_effect=[query_result, mutation_result, mutation_result]),
+        ):
+            _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
+
+        assert "Updated 'Status' in project 'My Board'" in caplog.text
+        assert "Updated 'Needs Action From' in project 'My Board'" in caplog.text
+
+    def test_skips_missing_fields(self, caplog: pytest.LogCaptureFixture):
+        nodes = [
+            {
+                "id": "item-1",
+                "project": {
+                    "id": "proj-1",
+                    "title": "Simple Board",
+                    "statusField": None,
+                    "actionField": None,
+                },
+            }
+        ]
+        query_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=self._graphql_response(nodes), stderr=""
+        )
+        with (
+            caplog.at_level("INFO", logger="askcc.functions"),
+            patch("askcc.functions.subprocess.run", return_value=query_result) as mock_run,
+        ):
+            _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
+
+        # Only the query call, no mutation calls
+        mock_run.assert_called_once()
+
+    def test_skips_unmatched_status_options(self):
+        nodes = [
+            {
+                "id": "item-1",
+                "project": {
+                    "id": "proj-1",
+                    "title": "Board",
+                    "statusField": {
+                        "id": "field-status",
+                        "options": [{"id": "opt-todo", "name": "Todo"}, {"id": "opt-done", "name": "Done"}],
+                    },
+                    "actionField": None,
+                },
+            }
+        ]
+        query_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=self._graphql_response(nodes), stderr=""
+        )
+        with patch("askcc.functions.subprocess.run", return_value=query_result) as mock_run:
+            _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
+
+        mock_run.assert_called_once()
+
+    def test_query_failure_warns(self, caplog: pytest.LogCaptureFixture):
+        with (
+            caplog.at_level("WARNING", logger="askcc.functions"),
+            patch(
+                "askcc.functions.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="graphql error"),
+            ),
+        ):
+            _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
+
+        assert "Failed to query project items" in caplog.text
+
+
+class TestTransitionIssueToReview:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/42"
+
+    def test_calls_label_swap_and_project_transition(self):
+        with (
+            patch("askcc.functions.shutil.which", return_value="/usr/bin/gh"),
+            patch("askcc.functions._swap_issue_labels") as mock_swap,
+            patch("askcc.functions._transition_project_fields") as mock_project,
+        ):
+            transition_issue_to_review(self.ISSUE_URL)
+
+        mock_swap.assert_called_once_with(
+            "/usr/bin/gh", "monkut/askcc-cli", 42, remove="action:develop", add="action:review"
+        )
+        mock_project.assert_called_once_with("/usr/bin/gh", "monkut", "askcc-cli", 42)
+
+
+class TestDevelopTransitionIntegration:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/1"
+
+    def test_develop_success_triggers_transition(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.validate_issue_readiness", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_review") as mock_transition,
+            patch("sys.argv", ["askcc", "develop", "--skip-validation", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_transition.assert_called_once_with(self.ISSUE_URL)
+
+    def test_develop_failure_skips_transition(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.validate_issue_readiness", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(1, None)),
+            patch("askcc.cli.transition_issue_to_review") as mock_transition,
+            patch("sys.argv", ["askcc", "develop", "--skip-validation", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_transition.assert_not_called()
+
+    def test_plan_success_skips_transition(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_review") as mock_transition,
+            patch("sys.argv", ["askcc", "plan", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_transition.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #31

- After successful PR creation (`develop` exit code 0), automatically swaps `action:develop` → `action:review` labels via `gh issue edit`
- Queries GitHub Projects v2 via GraphQL to update `Status` field to `in-internal-review` or `in-review` (whichever exists)
- Sets `Needs Action From` to `REVIEWER` if the project field exists
- All transition failures are logged as warnings, never errors — existing behavior unchanged when no labels/project are configured

## Test plan

- [x] 73 tests pass (16 new tests covering label swap, project field transitions, option matching, CLI integration)
- [x] Ruff lint/format clean
- [ ] Manual: run `askcc develop -g <issue-url>` on an issue with `action:develop` label and verify label swap
- [ ] Manual: verify project board column updates on an issue linked to a project