### PR TITLE
Add prepare command for backlog issue preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uvx --from . --python 3.14 askcc --help
 ## Usage
 
 ```
-askcc [--cwd DIR] {plan,validate,develop,review,explore,diagnose} --github-issue-url URL
+askcc [--cwd DIR] {prepare,plan,validate,develop,review,explore,diagnose} --github-issue-url URL
 askcc install [--directory DIR]
 ```
 
@@ -38,6 +38,7 @@ askcc install [--directory DIR]
 
 | Command    | Description                                                              |
 |------------|--------------------------------------------------------------------------|
+| `prepare`  | Analyze a backlog issue for development readiness (acceptance criteria, dependencies, estimates) |
 | `plan`     | Fetch the issue and run Claude in planning mode (architecture/design)    |
 | `validate` | Check issue readiness for development (acceptance criteria, dependencies, assignee, blocking labels) |
 | `develop`  | Fetch the issue and run Claude in development mode (implementation)      |
@@ -71,6 +72,8 @@ On first run, askcc creates `~/.askcc/templates/` with default template files:
 
 | File                       | Required variables | Description                          |
 |----------------------------|--------------------|--------------------------------------|
+| `PREPARE_SYSTEM_PROMPT.md`   | —                  | System prompt for the prepare agent    |
+| `PREPARE_USER_PROMPT.md`     | `$issue_content`   | User prompt template for preparation   |
 | `PLAN_SYSTEM_PROMPT.md`      | —                  | System prompt for the planning agent   |
 | `PLAN_USER_PROMPT.md`        | `$issue_content`   | User prompt template for planning      |
 | `DEVELOP_SYSTEM_PROMPT.md`   | —                  | System prompt for the dev agent        |
@@ -87,6 +90,12 @@ Edit any file to customize the agent's behavior. User prompt templates **must** 
 Override the config directory by setting the `ASKCC_HOME` environment variable (e.g. for testing).
 
 ### Examples
+
+Prepare a backlog issue for development:
+
+```bash
+askcc prepare --github-issue-url https://github.com/monkut/askcc-cli/issues/1
+```
 
 Plan an issue:
 

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -16,6 +16,7 @@ from .functions import (
     fetch_github_issue,
     install_skills,
     load_agent_config,
+    transition_issue_to_planning,
     transition_issue_to_review,
     validate_issue_labels,
     validate_issue_readiness,
@@ -136,6 +137,9 @@ def main() -> None:  # noqa: PLR0915
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    prepare_parser = subparsers.add_parser("prepare", help="Analyze a backlog issue for development readiness.")
+    prepare_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to prepare.")
+
     plan_parser = subparsers.add_parser("plan", help="Run Claude in plan mode (read-only analysis).")
     plan_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to plan.")
 
@@ -180,7 +184,7 @@ def main() -> None:  # noqa: PLR0915
 
     bootstrap_templates()
 
-    if not args.ignore_labels:
+    if not args.ignore_labels and args.command != "prepare":
         label_errors = validate_issue_labels(args.github_issue_url)
         if label_errors:
             for error in label_errors:
@@ -205,6 +209,9 @@ def main() -> None:  # noqa: PLR0915
 
     if usage:
         append_usage_to_last_comment(args.github_issue_url, usage)
+
+    if args.command == "prepare" and return_code == 0:
+        transition_issue_to_planning(args.github_issue_url)
 
     if args.command == "develop" and return_code == 0:
         transition_issue_to_review(args.github_issue_url)

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -27,6 +27,56 @@ If the label exists, apply it to the issue with `gh issue edit <number> --add-la
 Do not create the label if it does not exist.
 """
 
+PREPARE_AGENT_PROMPT = (
+    """\
+You are an issue preparation specialist operating inside Claude Code with access to the filesystem, git, and the gh CLI.
+
+Goal: Analyze the given GitHub issue for development readiness and post a structured preparation comment \
+that fills gaps, adds acceptance criteria, identifies dependencies, and suggests an estimate.
+
+Read relevant source files, tests, and configuration before forming your analysis. \
+Do not speculate about code you have not opened.
+
+Your preparation must include:
+1. **Readiness assessment** — evaluate the issue against these criteria:
+   - Does it have clear, verifiable acceptance criteria?
+   - Are dependencies and blockers identified?
+   - Is the scope well-defined and appropriately sized?
+   - Are there unanswered questions that would block implementation?
+
+2. **Suggested acceptance criteria** — if the issue lacks acceptance criteria or they are incomplete, \
+propose concrete, verifiable checklist items (using `- [ ]` syntax).
+
+3. **Dependencies and blockers** — identify any issues, PRs, external services, or decisions \
+that this issue depends on. Reference them by URL or number where possible.
+
+4. **Estimate suggestion** — suggest an estimate label based on the scope of work: \
+`estimate:1h`, `estimate:4h`, `estimate:1d`, `estimate:3d`, or `estimate:1w`. \
+Justify your estimate briefly.
+
+5. **Questions for the author** — list specific questions about any underspecified or ambiguous aspects.
+
+When your analysis reveals unresolved ambiguities or competing approaches that require a decision, \
+include a structured decision block in your comment.
+"""
+    + DECISION_GUIDANCE
+    + """
+Format your comment with clear markdown headings for each section.
+
+IMPORTANT: You MUST post your complete preparation analysis as a comment on the GitHub issue using the gh CLI. \
+Extract the issue URL from the provided issue content and use `gh issue comment <url> --body "<your analysis>"`. \
+Do NOT skip this step — the comment is the primary deliverable of this task.
+"""
+)
+
+PREPARE_USER_PROMPT_TEMPLATE = (
+    "Analyze the following GitHub issue for development readiness."
+    " Assess completeness, suggest acceptance criteria, identify dependencies,"
+    " suggest an estimate label, and list any questions for the author."
+    " You MUST post your complete preparation analysis as a comment on the GitHub issue using the gh CLI."
+    "\n\n$issue_content"
+)
+
 PLAN_AGENT_PROMPT = (
     """\
 You are a software architect operating inside Claude Code with access to the filesystem, git, and the gh CLI.
@@ -231,6 +281,7 @@ class SupportedLanguage(StrEnum):
 
 
 class AgentAction(StrEnum):
+    PREPARE = "prepare"
     PLAN = "plan"
     DEVELOP = "develop"
     REVIEW = "review"
@@ -239,6 +290,15 @@ class AgentAction(StrEnum):
 
 
 AGENT_CONFIGS: dict[AgentAction, AgentConfig] = {
+    AgentAction.PREPARE: AgentConfig(
+        action_name="prepare",
+        description="Analyzes a backlog issue for development readiness and suggests improvements",
+        system_prompt=PREPARE_AGENT_PROMPT,
+        user_prompt_template=PREPARE_USER_PROMPT_TEMPLATE,
+        system_prompt_file="PREPARE_SYSTEM_PROMPT.md",
+        user_prompt_file="PREPARE_USER_PROMPT.md",
+        required_variables=("issue_content",),
+    ),
     AgentAction.PLAN: AgentConfig(
         action_name="plan",
         description="Plans implementation for given issue",

--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -14,6 +14,9 @@ from .settings import (
     BLOCKING_LABELS,
     DEVELOP_LABEL,
     ENABLE_ISSUE_LABEL_PREFIX_VALIDATION,
+    PLANNER_FIELD_NAME,
+    PLANNER_FIELD_VALUE,
+    PLANNING_STATUS_OPTIONS,
     REQUIRED_ISSUE_LABEL_PREFIXES,
     REVIEW_LABEL,
     REVIEW_STATUS_OPTIONS,
@@ -452,8 +455,17 @@ def _update_project_field(
         )
 
 
-def _transition_project_fields(gh: str, owner: str, repo: str, issue_number: int) -> None:
-    """Move issue to review status in project boards. Best-effort, warns on failure."""
+def _transition_project_fields(
+    gh: str,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    *,
+    status_options: tuple[str, ...] = REVIEW_STATUS_OPTIONS,
+    action_field_value: str = REVIEWER_FIELD_VALUE,
+    action_field_name: str = REVIEWER_FIELD_NAME,
+) -> None:
+    """Move issue to a target status in project boards. Best-effort, warns on failure."""
     try:
         result = subprocess.run(  # noqa: S603
             [
@@ -493,7 +505,7 @@ def _transition_project_fields(gh: str, owner: str, repo: str, issue_number: int
         # Update Status field
         status_field = project.get("statusField")
         if status_field and status_field.get("options"):
-            option_id = _find_option_id(status_field["options"], REVIEW_STATUS_OPTIONS)
+            option_id = _find_option_id(status_field["options"], status_options)
             if option_id:
                 _update_project_field(
                     gh,
@@ -509,7 +521,7 @@ def _transition_project_fields(gh: str, owner: str, repo: str, issue_number: int
         # Update Needs Action From field
         action_field = project.get("actionField")
         if action_field and action_field.get("options"):
-            option_id = _find_option_id(action_field["options"], (REVIEWER_FIELD_VALUE,))
+            option_id = _find_option_id(action_field["options"], (action_field_value,))
             if option_id:
                 _update_project_field(
                     gh,
@@ -519,8 +531,44 @@ def _transition_project_fields(gh: str, owner: str, repo: str, issue_number: int
                     option_id,
                     issue_number=issue_number,
                     project_title=project_title,
-                    field_name=REVIEWER_FIELD_NAME,
+                    field_name=action_field_name,
                 )
+
+
+def _add_issue_label(gh: str, repo_nwo: str, issue_number: int, label: str) -> None:
+    """Add a label to a GitHub issue. Warns on failure."""
+    try:
+        subprocess.run(  # noqa: S603
+            [gh, "issue", "edit", str(issue_number), "-R", repo_nwo, "--add-label", label],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info("Added label '%s' to issue #%d", label, issue_number)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Failed to add label '%s' to issue #%d: %s", label, issue_number, exc.stderr)
+
+
+def transition_issue_to_planning(github_issue_url: str) -> None:
+    """Transition issue to planning state after successful preparation.
+
+    Adds action:develop label and moves to planning column.
+    All failures are logged as warnings, never raised.
+    """
+    gh = _require_gh_cli()
+    owner, repo, issue_number = _parse_issue_url(github_issue_url)
+    repo_nwo = f"{owner}/{repo}"
+
+    _add_issue_label(gh, repo_nwo, issue_number, DEVELOP_LABEL)
+    _transition_project_fields(
+        gh,
+        owner,
+        repo,
+        issue_number,
+        status_options=PLANNING_STATUS_OPTIONS,
+        action_field_value=PLANNER_FIELD_VALUE,
+        action_field_name=PLANNER_FIELD_NAME,
+    )
 
 
 def transition_issue_to_review(github_issue_url: str) -> None:

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -18,6 +18,11 @@ REQUIRED_ISSUE_LABEL_PREFIXES: tuple[str, ...] = ("action:",)
 DEVELOP_LABEL = "action:develop"
 REVIEW_LABEL = "action:review"
 
+# Prepare transition
+PLANNING_STATUS_OPTIONS: tuple[str, ...] = ("planning",)
+PLANNER_FIELD_NAME = "Needs Action From"
+PLANNER_FIELD_VALUE = "PLANNER"
+
 # Project field transition
 REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
 REVIEWER_FIELD_NAME = "Needs Action From"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 from askcc.cli import _run_claude, main
 from askcc.definitions import AGENT_CONFIGS, AgentAction, AgentConfig, SupportedLanguage
 from askcc.functions import (
+    _add_issue_label,
     _find_option_id,
     _has_acceptance_criteria,
     _has_dependencies_section,
@@ -25,6 +26,7 @@ from askcc.functions import (
     install_skills,
     load_agent_config,
     load_template,
+    transition_issue_to_planning,
     transition_issue_to_review,
     validate_issue_readiness,
     validate_template,
@@ -54,6 +56,8 @@ class TestParseIssueUrl:
 
 
 EXPECTED_TEMPLATE_FILES = {
+    "PREPARE_SYSTEM_PROMPT.md",
+    "PREPARE_USER_PROMPT.md",
     "PLAN_SYSTEM_PROMPT.md",
     "PLAN_USER_PROMPT.md",
     "DEVELOP_SYSTEM_PROMPT.md",
@@ -899,6 +903,112 @@ class TestDevelopTransitionIntegration:
             patch("askcc.cli._run_claude", return_value=(0, None)),
             patch("askcc.cli.transition_issue_to_review") as mock_transition,
             patch("sys.argv", ["askcc", "plan", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_transition.assert_not_called()
+
+
+class TestLoadPrepareConfig:
+    def test_load_prepare_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentAction.PREPARE)
+        assert config.action_name == "prepare"
+        assert config.description == "Analyzes a backlog issue for development readiness and suggests improvements"
+
+
+class TestAddIssueLabel:
+    def test_success(self, caplog: pytest.LogCaptureFixture):
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            caplog.at_level("INFO", logger="askcc.functions"),
+            patch("askcc.functions.subprocess.run", return_value=ok) as mock_run,
+        ):
+            _add_issue_label("/usr/bin/gh", "owner/repo", 42, "action:develop")
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "--add-label" in cmd
+        assert "action:develop" in cmd
+        assert "Added label" in caplog.text
+
+    def test_failure_warns(self, caplog: pytest.LogCaptureFixture):
+        with (
+            caplog.at_level("WARNING", logger="askcc.functions"),
+            patch(
+                "askcc.functions.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="label not found"),
+            ),
+        ):
+            _add_issue_label("/usr/bin/gh", "owner/repo", 42, "action:develop")
+
+        assert "Failed to add label" in caplog.text
+
+
+class TestTransitionIssueToPlanningIntegration:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/42"
+
+    def test_calls_add_label_and_project_transition(self):
+        with (
+            patch("askcc.functions.shutil.which", return_value="/usr/bin/gh"),
+            patch("askcc.functions._add_issue_label") as mock_add,
+            patch("askcc.functions._transition_project_fields") as mock_project,
+        ):
+            transition_issue_to_planning(self.ISSUE_URL)
+
+        mock_add.assert_called_once_with("/usr/bin/gh", "monkut/askcc-cli", 42, "action:develop")
+        mock_project.assert_called_once_with(
+            "/usr/bin/gh",
+            "monkut",
+            "askcc-cli",
+            42,
+            status_options=("planning",),
+            action_field_value="PLANNER",
+            action_field_name="Needs Action From",
+        )
+
+
+class TestPrepareCommand:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/1"
+
+    def test_prepare_skips_label_validation(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels") as mock_labels,
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_planning"),
+            patch("sys.argv", ["askcc", "prepare", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_labels.assert_not_called()
+
+    def test_prepare_success_triggers_planning_transition(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_planning") as mock_transition,
+            patch("sys.argv", ["askcc", "prepare", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_transition.assert_called_once_with(self.ISSUE_URL)
+
+    def test_prepare_failure_skips_transition(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli._run_claude", return_value=(1, None)),
+            patch("askcc.cli.transition_issue_to_planning") as mock_transition,
+            patch("sys.argv", ["askcc", "prepare", "-g", self.ISSUE_URL]),
             pytest.raises(SystemExit),
         ):
             main()


### PR DESCRIPTION
## Summary

- Add `askcc prepare` subcommand that analyzes backlog issues for development readiness
- Posts structured preparation comments with acceptance criteria, dependencies, estimate suggestions, and author questions
- On success, adds `action:develop` label and transitions project board to `planning` column
- Skips label validation for `prepare` since unplanned issues may not have `action:` labels

Closes #32

## Test plan

- [x] All 80 tests pass (`uv run poe test`)
- [x] Ruff linting clean (`uv run poe check`)
- [x] Pyright type checking clean (`uv run poe typecheck`)
- [ ] Manual test: `askcc prepare -g <issue-url>` on a backlog issue