### PR TITLE
Add reviewpr command for PR code review (#30)

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -14,6 +14,7 @@ from .functions import (
     append_usage_to_last_comment,
     bootstrap_templates,
     fetch_github_issue,
+    fetch_pr_content,
     install_skills,
     load_agent_config,
     transition_issue_to_planning,
@@ -91,6 +92,14 @@ def _run_claude(
     return result.returncode, usage
 
 
+def _build_prompt(command: str, config: AgentConfig, issue_content: str, issue_url: str) -> str:
+    """Build the user prompt, fetching PR content for reviewpr commands."""
+    if command == "reviewpr":
+        pr_content = fetch_pr_content(issue_url)
+        return Template(config.user_prompt_template).safe_substitute(issue_content=issue_content, pr_content=pr_content)
+    return Template(config.user_prompt_template).safe_substitute(issue_content=issue_content)
+
+
 def _print_validation_report(issue_url: str, checks: list[CheckResult]) -> None:
     """Print a structured pass/fail validation report."""
     passed_count = sum(1 for c in checks if c.passed)
@@ -105,7 +114,7 @@ def _print_validation_report(issue_url: str, checks: list[CheckResult]) -> None:
     print(f"Result: {result} ({passed_count}/{total} checks passed)")  # noqa: T201
 
 
-def main() -> None:  # noqa: PLR0915
+def main() -> None:  # noqa: PLR0912, PLR0915, C901
     configure_logging()
     parser = argparse.ArgumentParser(description="A one-shot Claude Code CLI executor.")
     parser.add_argument(
@@ -155,6 +164,9 @@ def main() -> None:  # noqa: PLR0915
     review_parser = subparsers.add_parser("review", help="Run Claude in review mode (issue quality review).")
     review_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL to review.")
 
+    reviewpr_parser = subparsers.add_parser("reviewpr", help="Review a PR's code against its linked issue.")
+    reviewpr_parser.add_argument("-g", "--github-issue-url", required=True, help="GitHub issue URL with linked PR.")
+
     explore_parser = subparsers.add_parser(
         "explore", help="Run Claude in explore mode (investigate and propose solutions)."
     )
@@ -201,7 +213,11 @@ def main() -> None:  # noqa: PLR0915
     agent = AgentAction(args.command)
     config = load_agent_config(agent)
     issue_content = fetch_github_issue(args.github_issue_url)
-    prompt = Template(config.user_prompt_template).safe_substitute(issue_content=issue_content)
+    try:
+        prompt = _build_prompt(args.command, config, issue_content, args.github_issue_url)
+    except ValueError:
+        logger.exception("Failed to build prompt for '%s' command", args.command)
+        sys.exit(1)
     if args.language != SupportedLanguage.ENGLISH:
         prompt += f"\nOutput all comments in {args.language}."
     logger.info("Prompt prepared for '%s' command", agent.value)

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -245,6 +245,53 @@ DIAGNOSE_USER_PROMPT_TEMPLATE = (
     "\n\n$issue_content"
 )
 
+REVIEWPR_AGENT_PROMPT = (
+    """\
+You are a code reviewer operating inside Claude Code with access to the filesystem, git, and the gh CLI.
+
+Goal: Review the pull request linked to the given GitHub issue, verify it meets the Definition of Done, \
+and post a structured review on the PR.
+
+Pre-review:
+- The PR diff and metadata are provided in the prompt. Read them carefully.
+- Check out the PR branch using `gh pr checkout <number>` to inspect the full source.
+- Run the project's test suite to confirm all tests pass.
+
+Definition of Done checklist:
+1. **Acceptance criteria** — verify each criterion from the issue is satisfied by the code changes.
+2. **Test coverage** — new and changed logic has unit tests. Look for untested code paths.
+3. **Tests pass** — run the test suite and confirm all tests pass.
+4. **Documentation** — if behavior changed, docs/README/comments are updated.
+5. **No regressions** — no removed or broken existing functionality.
+6. **Security** — no injection vulnerabilities, exposed secrets, unsafe input handling.
+7. **Code quality** — clean, consistent style, no dead code, follows project conventions.
+
+Your review must include:
+- A summary of the PR changes and their alignment with the issue requirements.
+- A Definition of Done checklist with PASS/FAIL for each criterion and brief justification.
+- Specific code comments on issues found (file path, line, problem, suggestion).
+- A clear verdict: **APPROVE** or **REQUEST CHANGES**.
+
+Posting the review:
+- If all criteria pass: use `gh pr review <number> -R <owner/repo> --approve --body "<review>"`
+- If any criteria fail: use `gh pr review <number> -R <owner/repo> --request-changes --body "<review>"`
+- Also post a brief summary comment on the linked issue using `gh issue comment`.
+"""
+    + DECISION_GUIDANCE
+    + """
+IMPORTANT: You MUST post your review on the pull request using `gh pr review`. \
+Do NOT skip this step — the PR review is the primary deliverable of this task.
+"""
+)
+
+REVIEWPR_USER_PROMPT_TEMPLATE = (
+    "Review the following pull request against its linked GitHub issue."
+    " Verify the Definition of Done criteria and post a structured review on the PR"
+    " using `gh pr review`."
+    "\n\n$issue_content"
+    "\n\n$pr_content"
+)
+
 REVIEW_USER_PROMPT_TEMPLATE = (
     "Review the following GitHub issue for clarity, completeness, and feasibility."
     " You MUST post your complete review as a comment on the GitHub issue using the gh CLI."
@@ -285,6 +332,7 @@ class AgentAction(StrEnum):
     PLAN = "plan"
     DEVELOP = "develop"
     REVIEW = "review"
+    REVIEWPR = "reviewpr"
     EXPLORE = "explore"
     DIAGNOSE = "diagnose"
 
@@ -325,6 +373,15 @@ AGENT_CONFIGS: dict[AgentAction, AgentConfig] = {
         system_prompt_file="REVIEW_SYSTEM_PROMPT.md",
         user_prompt_file="REVIEW_USER_PROMPT.md",
         required_variables=("issue_content",),
+    ),
+    AgentAction.REVIEWPR: AgentConfig(
+        action_name="reviewpr",
+        description="Reviews a pull request against its linked issue's Definition of Done",
+        system_prompt=REVIEWPR_AGENT_PROMPT,
+        user_prompt_template=REVIEWPR_USER_PROMPT_TEMPLATE,
+        system_prompt_file="REVIEWPR_SYSTEM_PROMPT.md",
+        user_prompt_file="REVIEWPR_USER_PROMPT.md",
+        required_variables=("issue_content", "pr_content"),
     ),
     AgentAction.EXPLORE: AgentConfig(
         action_name="explore",

--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -86,6 +86,97 @@ def fetch_github_issue(github_issue_url: str) -> str:
     return "\n\n".join(sections)
 
 
+def _find_linked_pr_number(gh: str, owner: str, repo: str, issue_number: int) -> int | None:
+    """Find the most recent open PR linked to the given issue number.
+
+    Searches by branch naming convention (e.g. feature/N-*, add/N-*) first,
+    then falls back to matching issue references in PR body text.
+    """
+    repo_nwo = f"{owner}/{repo}"
+    try:
+        result = subprocess.run(  # noqa: S603
+            [gh, "pr", "list", "-R", repo_nwo, "--json", "number,headRefName,body", "--limit", "50"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        prs = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to list PRs for %s: %s", repo_nwo, exc)
+        return None
+
+    # Match branch names like "type/N-description" (askcc convention)
+    branch_pattern = re.compile(rf"^[^/]+/{issue_number}-")
+    for pr in prs:
+        if branch_pattern.match(pr.get("headRefName", "")):
+            return pr["number"]
+
+    # Fallback: check PR body for issue reference
+    for pr in prs:
+        body = pr.get("body", "") or ""
+        if f"#{issue_number}" in body or f"/issues/{issue_number}" in body:
+            return pr["number"]
+
+    return None
+
+
+def fetch_pr_content(github_issue_url: str) -> str:
+    """Fetch the linked PR's metadata, diff, and review comments for code review."""
+    gh = _require_gh_cli()
+    owner, repo, issue_number = _parse_issue_url(github_issue_url)
+    repo_nwo = f"{owner}/{repo}"
+
+    pr_number = _find_linked_pr_number(gh, owner, repo, issue_number)
+    if pr_number is None:
+        msg = f"No linked pull request found for issue #{issue_number} in {repo_nwo}"
+        raise ValueError(msg)
+
+    logger.info("Found linked PR #%d for issue #%d", pr_number, issue_number)
+
+    # Fetch PR metadata
+    pr_result = subprocess.run(  # noqa: S603
+        [gh, "api", f"repos/{repo_nwo}/pulls/{pr_number}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pr_data = json.loads(pr_result.stdout)
+    pr_title = pr_data.get("title", "")
+    pr_body = pr_data.get("body", "") or ""
+    pr_url = pr_data.get("html_url", "")
+
+    # Fetch PR diff
+    diff_result = subprocess.run(  # noqa: S603
+        [gh, "api", f"repos/{repo_nwo}/pulls/{pr_number}", "-H", "Accept: application/vnd.github.v3.diff"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    diff = diff_result.stdout
+
+    # Fetch PR review comments
+    comments_result = subprocess.run(  # noqa: S603
+        [gh, "api", "--paginate", f"repos/{repo_nwo}/pulls/{pr_number}/comments"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    comments = json.loads(comments_result.stdout)
+    comment_texts = [
+        f"Review comment by @{c['user']['login']} on {c.get('path', 'unknown')}:\n{c['body']}" for c in comments
+    ]
+
+    sections = [
+        f"Pull Request #{pr_number}\nURL: {pr_url}\nTitle: {pr_title}\n\n{pr_body}",
+        f"PR Diff:\n{diff}",
+    ]
+    if comment_texts:
+        sections.append("Existing Review Comments:\n" + "\n---\n".join(comment_texts))
+
+    logger.info("Fetched PR #%d with %d review comment(s)", pr_number, len(comment_texts))
+    return "\n\n".join(sections)
+
+
 def validate_issue_labels(github_issue_url: str) -> list[str]:
     """Validate that the issue has at least one label matching each required prefix.
 

--- a/askcc/skills/request-askcc/SKILL.md
+++ b/askcc/skills/request-askcc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-askcc
-description: Request REVIEW, PLAN, DEVELOP, EXPLORE or DIAGNOSE actions for GitHub issues via the askcc CLI. Use when a user asks to review, plan, develop, explore, or diagnose a GitHub issue.
+description: Request REVIEW, REVIEWPR, PLAN, DEVELOP, EXPLORE or DIAGNOSE actions for GitHub issues via the askcc CLI. Use when a user asks to review, plan, develop, explore, diagnose, or review a PR for a GitHub issue.
 ---
 
 # Request GitHub Issue Action
@@ -14,6 +14,7 @@ Use the `askcc` tool to request processing (plan or develop) of GitHub issues de
 - When a user asks to REVIEW a github issue, use `askcc review`.
 - When a user asks to EXPLORE a github issue (investigate and propose solutions), use `askcc explore`.
 - When a user asks to DIAGNOSE a github issue (root cause analysis), use `askcc diagnose`.
+- When a user asks to REVIEW a PR (code review of a pull request linked to an issue), use `askcc reviewpr`.
 
 ## Examples
 
@@ -51,6 +52,13 @@ Use the `askcc` tool to request processing (plan or develop) of GitHub issues de
   ```bash
   # This investigates the reported issue, identifies potential root causes, and requests additional information.
   askcc diagnose --cwd {PROJECTS DIRECTORY}/{TARGET DEVELOPMENT REPOSITORY} --github-issue-url https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1
+  ```
+
+- "Review the PR for https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1"
+
+  ```bash
+  # This fetches the issue and its linked PR, reviews the code against Definition of Done criteria, and posts a structured review on the PR.
+  askcc reviewpr --cwd {PROJECTS DIRECTORY}/{TARGET DEVELOPMENT REPOSITORY} --github-issue-url https://github.com/{GITHUB ORG}/{GITHUB REPO}/issues/1
   ```
 
 WARNING: If the `{TARGET DEVELOPMENT REPOSITORY}` cannot be determined, ASK user in Slack.

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -15,6 +15,7 @@ from askcc.cli import _run_claude, main
 from askcc.definitions import AGENT_CONFIGS, AgentAction, AgentConfig, SupportedLanguage
 from askcc.functions import (
     _add_issue_label,
+    _find_linked_pr_number,
     _find_option_id,
     _has_acceptance_criteria,
     _has_dependencies_section,
@@ -23,6 +24,7 @@ from askcc.functions import (
     _transition_project_fields,
     append_usage_to_last_comment,
     bootstrap_templates,
+    fetch_pr_content,
     install_skills,
     load_agent_config,
     load_template,
@@ -64,6 +66,8 @@ EXPECTED_TEMPLATE_FILES = {
     "DEVELOP_USER_PROMPT.md",
     "REVIEW_SYSTEM_PROMPT.md",
     "REVIEW_USER_PROMPT.md",
+    "REVIEWPR_SYSTEM_PROMPT.md",
+    "REVIEWPR_USER_PROMPT.md",
     "EXPLORE_SYSTEM_PROMPT.md",
     "EXPLORE_USER_PROMPT.md",
     "DIAGNOSE_SYSTEM_PROMPT.md",
@@ -1014,3 +1018,206 @@ class TestPrepareCommand:
             main()
 
         mock_transition.assert_not_called()
+
+
+class TestFindLinkedPrNumber:
+    def test_matches_branch_convention(self):
+        prs = json.dumps(
+            [
+                {"number": 10, "headRefName": "feature/42-add-feature", "body": "unrelated"},
+                {"number": 11, "headRefName": "main", "body": ""},
+            ]
+        )
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 10
+
+    def test_matches_add_prefix(self):
+        prs = json.dumps([{"number": 5, "headRefName": "add/42-new-thing", "body": ""}])
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 5
+
+    def test_falls_back_to_body_reference(self):
+        prs = json.dumps([{"number": 7, "headRefName": "my-branch", "body": "Closes #42"}])
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 7
+
+    def test_matches_issue_url_in_body(self):
+        prs = json.dumps(
+            [
+                {"number": 8, "headRefName": "topic", "body": "See /issues/42 for details"},
+            ]
+        )
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 8
+
+    def test_prefers_branch_over_body(self):
+        prs = json.dumps(
+            [
+                {"number": 1, "headRefName": "other", "body": "Fixes #42"},
+                {"number": 2, "headRefName": "feature/42-impl", "body": ""},
+            ]
+        )
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 2
+
+    def test_returns_none_when_no_match(self):
+        prs = json.dumps([{"number": 1, "headRefName": "main", "body": "unrelated changes"}])
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) is None
+
+    def test_returns_none_on_empty_list(self):
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) is None
+
+    def test_returns_none_on_subprocess_error(self, caplog: pytest.LogCaptureFixture):
+        with (
+            caplog.at_level("WARNING", logger="askcc.functions"),
+            patch(
+                "askcc.functions.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="api error"),
+            ),
+        ):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) is None
+        assert "Failed to list PRs" in caplog.text
+
+    def test_null_body_handled(self):
+        prs = json.dumps([{"number": 3, "headRefName": "feature/42-fix", "body": None}])
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with patch("askcc.functions.subprocess.run", return_value=result):
+            assert _find_linked_pr_number("/usr/bin/gh", "owner", "repo", 42) == 3
+
+
+class TestFetchPrContent:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/42"
+
+    def _make_pr_responses(
+        self,
+        *,
+        pr_number: int = 10,
+        pr_title: str = "Add feature",
+        pr_body: str = "Implements #42",
+        pr_url: str = "https://github.com/monkut/askcc-cli/pull/10",
+        diff: str = "diff --git a/file.py\n+new line",
+        review_comments: list[dict] | None = None,
+    ) -> list[subprocess.CompletedProcess]:
+        # PR list (for _find_linked_pr_number)
+        prs = json.dumps([{"number": pr_number, "headRefName": "feature/42-add", "body": pr_body}])
+        list_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+
+        # PR metadata
+        pr_data = json.dumps({"title": pr_title, "body": pr_body, "html_url": pr_url})
+        meta_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=pr_data, stderr="")
+
+        # PR diff
+        diff_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=diff, stderr="")
+
+        # PR review comments
+        comments = json.dumps(review_comments or [])
+        comments_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=comments, stderr="")
+
+        return [list_result, meta_result, diff_result, comments_result]
+
+    def test_fetches_pr_content(self):
+        responses = self._make_pr_responses()
+        with (
+            patch("askcc.functions.shutil.which", return_value="/usr/bin/gh"),
+            patch("askcc.functions.subprocess.run", side_effect=responses),
+        ):
+            content = fetch_pr_content(self.ISSUE_URL)
+
+        assert "Pull Request #10" in content
+        assert "Add feature" in content
+        assert "diff --git" in content
+
+    def test_includes_review_comments(self):
+        comments = [{"user": {"login": "reviewer1"}, "path": "file.py", "body": "Looks good"}]
+        responses = self._make_pr_responses(review_comments=comments)
+        with (
+            patch("askcc.functions.shutil.which", return_value="/usr/bin/gh"),
+            patch("askcc.functions.subprocess.run", side_effect=responses),
+        ):
+            content = fetch_pr_content(self.ISSUE_URL)
+
+        assert "Review comment by @reviewer1" in content
+        assert "Looks good" in content
+
+    def test_raises_when_no_linked_pr(self):
+        prs = json.dumps([])
+        list_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=prs, stderr="")
+        with (
+            patch("askcc.functions.shutil.which", return_value="/usr/bin/gh"),
+            patch("askcc.functions.subprocess.run", return_value=list_result),
+            pytest.raises(ValueError, match="No linked pull request found"),
+        ):
+            fetch_pr_content(self.ISSUE_URL)
+
+
+class TestLoadReviewprConfig:
+    def test_load_reviewpr_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        templates_dir = tmp_path / "templates"
+        monkeypatch.setattr("askcc.functions.TEMPLATES_DIR", templates_dir)
+        bootstrap_templates()
+
+        config = load_agent_config(AgentAction.REVIEWPR)
+        assert config.action_name == "reviewpr"
+        assert config.description == "Reviews a pull request against its linked issue's Definition of Done"
+        assert config.required_variables == ("issue_content", "pr_content")
+
+
+class TestReviewprCommand:
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/1"
+
+    def test_reviewpr_fetches_pr_content(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli.fetch_pr_content", return_value="pr diff content") as mock_pr,
+            patch("askcc.cli._run_claude", return_value=(0, None)) as mock_claude,
+            patch("sys.argv", ["askcc", "reviewpr", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_pr.assert_called_once_with(self.ISSUE_URL)
+        prompt = mock_claude.call_args[0][0]
+        assert "issue body" in prompt
+        assert "pr diff content" in prompt
+
+    def test_reviewpr_exits_on_no_linked_pr(self, caplog: pytest.LogCaptureFixture):
+        with (
+            caplog.at_level("ERROR", logger="askcc.cli"),
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli.fetch_pr_content", side_effect=ValueError("No linked pull request found")),
+            patch("sys.argv", ["askcc", "reviewpr", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            main()
+
+        assert "Failed to build prompt" in caplog.text
+
+    def test_reviewpr_no_transition_on_success(self):
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli.fetch_pr_content", return_value="pr content"),
+            patch("askcc.cli._run_claude", return_value=(0, None)),
+            patch("askcc.cli.transition_issue_to_review") as mock_review,
+            patch("askcc.cli.transition_issue_to_planning") as mock_planning,
+            patch("sys.argv", ["askcc", "reviewpr", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+
+        mock_review.assert_not_called()
+        mock_planning.assert_not_called()


### PR DESCRIPTION
## Summary

- Add `reviewpr` subcommand that fetches a GitHub issue and its linked PR, evaluates code against Definition of Done criteria, and posts a structured review on the PR
- Linked PR discovery uses branch naming convention (`type/N-description`) with fallback to body text reference matching
- Agent reviews against 7 DoD criteria: acceptance criteria, test coverage, tests pass, documentation, no regressions, security, code quality

## Test plan

- [x] 96 tests pass (13 new tests added)
- [x] `ruff check` passes
- [x] `pyright` passes with 0 errors
- [ ] Manual test: `askcc reviewpr -g <issue-url>` with a real issue/PR pair

Closes #30