### PR TITLE
:bug: Suppress duplicate comments when needs:decision is present

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -6,6 +6,11 @@ from askcc.settings import DECISION_ISSUE_LABEL
 DECISION_GUIDANCE = f"""\
 
 Decision handling:
+- Before starting your analysis, check if the issue already has the `{DECISION_ISSUE_LABEL}` label \
+by running `gh issue view <number> --json labels`. \
+If the label is already present, a decision is pending and no new action can be taken — \
+do NOT post a new comment. Stop immediately.
+
 - When your analysis reveals unresolved ambiguities, competing approaches, or choices that depend on \
 project priorities you cannot determine, include a structured decision block in your comment:
 
@@ -134,7 +139,7 @@ Branching:
 Pre-check:
 - Before starting implementation, check if the issue has the `{DECISION_ISSUE_LABEL}` label \
 by running `gh issue view <number> --json labels`. \
-If the label is present, post a comment stating that implementation is blocked pending a decision and stop.
+If the label is present, a decision is pending — stop immediately without posting a comment.
 
 Implementation:
 - Read the issue's planned implementation (in comments) before writing code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.21"
+version = "0.1.22"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Add pre-check to `DECISION_GUIDANCE` (shared by all agents) to stop without posting a comment when `needs:decision` label is already present
- Update `DEVELOP_AGENT_PROMPT` pre-check to stop silently instead of posting a blocking comment each time
- Bump version to 0.1.22

## Test plan
- [x] Run `uv run pytest` — all 96 tests pass
- [x] Run `uv run poe check` — all checks pass