### PR TITLE
Add issue body update instructions for prepare, explore, diagnose

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -68,14 +68,11 @@ include a structured decision block in your comment.
     + """
 Format your comment with clear markdown headings for each section.
 
-IMPORTANT: You MUST post your complete preparation analysis as a comment on the GitHub issue using the gh CLI. \
-Extract the issue URL from the provided issue content and use `gh issue comment <url> --body "<your analysis>"`. \
-Do NOT skip this step — the comment is the primary deliverable of this task.
+IMPORTANT: You MUST perform two actions — update the issue description AND post a summary comment.
 
-## Issue Body Update
+## Issue Description Update
 
-After posting the preparation comment, you MUST also update the GitHub issue body. \
-Use the gh CLI to append the following sections to the issue body if they are not already present:
+Update the GitHub issue body to append the following sections if not already present:
 
 1. **Acceptance Criteria** — Add a `## Acceptance Criteria <!-- draft -->` section containing \
 a checklist (using `- [ ]` markdown checkboxes) of the suggested acceptance criteria from your analysis.
@@ -87,6 +84,17 @@ The `<!-- draft -->` markers indicate these are AI-suggested and should be revie
 To update the issue body, first read the current body with `gh issue view <url> --json body -q .body`, \
 then append the missing sections and update with `gh issue edit <url> --body "<updated body>"`. \
 Preserve all existing content in the issue body — only append new sections.
+
+## Summary Comment
+
+After updating the description, post a comment on the issue summarizing:
+- What sections were added or updated in the issue description
+- Readiness assessment and current status
+- Estimate suggestion with brief justification
+- Open questions for the author (if any)
+
+The comment serves as an activity log entry — keep it concise. \
+Use `gh issue comment <url> --body "<your summary>"`.
 """
 )
 
@@ -94,7 +102,7 @@ PREPARE_USER_PROMPT_TEMPLATE = (
     "Analyze the following GitHub issue for development readiness."
     " Assess completeness, suggest acceptance criteria, identify dependencies,"
     " suggest an estimate label, and list any questions for the author."
-    " You MUST post your complete preparation analysis as a comment on the GitHub issue using the gh CLI."
+    " You MUST update the issue description and post a summary comment using the gh CLI."
     "\n\n$issue_content"
 )
 
@@ -234,27 +242,33 @@ you cannot determine, include a structured decision block in your comment.
 """
     + DECISION_GUIDANCE
     + """
-IMPORTANT: You MUST post your complete analysis as a comment on the GitHub issue using the gh CLI. \
-Extract the issue URL from the provided issue content and use `gh issue comment <url> --body "<your analysis>"`. \
-Do NOT skip this step — the comment is the primary deliverable of this task.
+IMPORTANT: You MUST perform two actions — update the issue description AND post a summary comment.
 
-## Issue Body Update
+## Issue Description Update
 
-After posting the exploration comment, you MUST also update the GitHub issue body. \
-Use the gh CLI to append a `## Proposed Approach` section if not already present. \
-This section should contain a 2–3 bullet summary of your recommended option. \
-The full trade-off analysis remains in the comment.
+Update the GitHub issue body to append a `## Proposed Approach` section if not already present. \
+This section should contain a 2–3 bullet summary of your recommended option.
 
 To update the issue body, first read the current body with `gh issue view <url> --json body -q .body`, \
 then append the missing section and update with `gh issue edit <url> --body "<updated body>"`. \
 Preserve all existing content in the issue body — only append new sections.
+
+## Summary Comment
+
+After updating the description, post a comment on the issue summarizing:
+- What sections were added or updated in the issue description
+- The recommended approach and key trade-offs considered
+- Open questions or risks that need clarification
+
+The comment serves as an activity log entry — keep it concise. \
+Use `gh issue comment <url> --body "<your summary>"`.
 """
 )
 
 EXPLORE_USER_PROMPT_TEMPLATE = (
     "Investigate the following GitHub issue, research the codebase,"
     " and propose best-practice solutions with trade-offs."
-    " You MUST post your complete analysis as a comment on the GitHub issue using the gh CLI."
+    " You MUST update the issue description and post a summary comment using the gh CLI."
     "\n\n$issue_content"
 )
 
@@ -280,27 +294,33 @@ or which fix approach to take, include a structured decision block in your comme
 """
     + DECISION_GUIDANCE
     + """
-IMPORTANT: You MUST post your complete diagnosis as a comment on the GitHub issue using the gh CLI. \
-Extract the issue URL from the provided issue content and use `gh issue comment <url> --body "<your diagnosis>"`. \
-Do NOT skip this step — the comment is the primary deliverable of this task.
+IMPORTANT: You MUST perform two actions — update the issue description AND post a summary comment.
 
-## Issue Body Update
+## Issue Description Update
 
-After posting the diagnosis comment, you MUST also update the GitHub issue body. \
-Use the gh CLI to append a `## Root Cause` section if not already present. \
-This section should contain the most likely root cause in 1–2 sentences. \
-The full diagnosis remains in the comment.
+Update the GitHub issue body to append a `## Root Cause` section if not already present. \
+This section should contain the most likely root cause in 1–2 sentences.
 
 To update the issue body, first read the current body with `gh issue view <url> --json body -q .body`, \
 then append the missing section and update with `gh issue edit <url> --body "<updated body>"`. \
 Preserve all existing content in the issue body — only append new sections.
+
+## Summary Comment
+
+After updating the description, post a comment on the issue summarizing:
+- What sections were added or updated in the issue description
+- Diagnostic findings and current status
+- Unknowns and information requests for the reporter
+
+The comment serves as an activity log entry — keep it concise. \
+Use `gh issue comment <url> --body "<your summary>"`.
 """
 )
 
 DIAGNOSE_USER_PROMPT_TEMPLATE = (
     "Investigate the following reported issue, identify potential causes,"
     " and request any additional information needed to confirm the diagnosis."
-    " You MUST post your complete diagnosis as a comment on the GitHub issue using the gh CLI."
+    " You MUST update the issue description and post a summary comment using the gh CLI."
     "\n\n$issue_content"
 )
 


### PR DESCRIPTION
## Summary
- **prepare** now appends `## Acceptance Criteria <!-- draft -->` and `## Dependencies <!-- draft -->` sections to the issue body after posting its comment
- **explore** now appends a `## Proposed Approach` section (2–3 bullet summary of the recommended option) to the issue body
- **diagnose** now appends a `## Root Cause` section (1–2 sentence summary) to the issue body
- **review**, **plan**, **develop** remain unchanged (review is comment-only, plan already updates the description, develop uses the PR as its artifact)

This keeps the issue description as the current task definition while comments serve as the activity log.

## Test plan
- [x] All 96 existing tests pass
- [x] Ruff linting passes
- [ ] Manually run `askcc prepare`, `askcc explore`, `askcc diagnose` against a test issue and verify the body is updated