### PR TITLE
Add test plan task completion to PR review prompt

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -368,6 +368,15 @@ Posting the review:
 - If all criteria pass: use `gh pr review <number> -R <owner/repo> --approve --body "<review>"`
 - If any criteria fail: use `gh pr review <number> -R <owner/repo> --request-changes --body "<review>"`
 - Also post a brief summary comment on the linked issue using `gh issue comment`.
+
+Update test plan in PR description:
+- After completing the review, read the PR description with `gh pr view <number> -R <owner/repo> --json body -q .body`.
+- Look for a `## Test plan` section containing checklist items (`- [ ]` checkboxes).
+- For each test plan task, determine whether it is satisfied by the code changes, test results, \
+or review findings.
+- Check off completed tasks by replacing `- [ ]` with `- [x]` in the PR body.
+- Update the PR description with `gh pr edit <number> -R <owner/repo> --body "<updated body>"`.
+- If no `## Test plan` section exists, skip this step.
 """
     + DECISION_GUIDANCE
     + """


### PR DESCRIPTION
## Summary
- Adds instructions to the REVIEWPR prompt so that after completing a review, the agent reads the PR description, finds any `## Test plan` checklist items, and checks off tasks that are satisfied by the code changes or review findings.

## Test plan
- [ ] Verify the REVIEWPR action reads and updates PR description test plan checkboxes
- [ ] Confirm no changes when `## Test plan` section is absent