### PR TITLE
:fire: Remove deprecated 'Needs Action From' project field

### DIFF
--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -14,14 +14,10 @@ from .settings import (
     BLOCKING_LABELS,
     DEVELOP_LABEL,
     ENABLE_ISSUE_LABEL_PREFIX_VALIDATION,
-    PLANNER_FIELD_NAME,
-    PLANNER_FIELD_VALUE,
     PLANNING_STATUS_OPTIONS,
     REQUIRED_ISSUE_LABEL_PREFIXES,
     REVIEW_LABEL,
     REVIEW_STATUS_OPTIONS,
-    REVIEWER_FIELD_NAME,
-    REVIEWER_FIELD_VALUE,
     TEMPLATES_DIR,
 )
 
@@ -474,12 +470,6 @@ query($owner: String!, $repo: String!, $number: Int!) {
                 options { id name }
               }
             }
-            actionField: field(name: "Needs Action From") {
-              ... on ProjectV2SingleSelectField {
-                id
-                options { id name }
-              }
-            }
           }
         }
       }
@@ -553,8 +543,6 @@ def _transition_project_fields(
     issue_number: int,
     *,
     status_options: tuple[str, ...] = REVIEW_STATUS_OPTIONS,
-    action_field_value: str = REVIEWER_FIELD_VALUE,
-    action_field_name: str = REVIEWER_FIELD_NAME,
 ) -> None:
     """Move issue to a target status in project boards. Best-effort, warns on failure."""
     try:
@@ -609,22 +597,6 @@ def _transition_project_fields(
                     field_name="Status",
                 )
 
-        # Update Needs Action From field
-        action_field = project.get("actionField")
-        if action_field and action_field.get("options"):
-            option_id = _find_option_id(action_field["options"], (action_field_value,))
-            if option_id:
-                _update_project_field(
-                    gh,
-                    project_id,
-                    item_id,
-                    action_field["id"],
-                    option_id,
-                    issue_number=issue_number,
-                    project_title=project_title,
-                    field_name=action_field_name,
-                )
-
 
 def _add_issue_label(gh: str, repo_nwo: str, issue_number: int, label: str) -> None:
     """Add a label to a GitHub issue. Warns on failure."""
@@ -657,8 +629,6 @@ def transition_issue_to_planning(github_issue_url: str) -> None:
         repo,
         issue_number,
         status_options=PLANNING_STATUS_OPTIONS,
-        action_field_value=PLANNER_FIELD_VALUE,
-        action_field_name=PLANNER_FIELD_NAME,
     )
 
 

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -20,13 +20,9 @@ REVIEW_LABEL = "action:review"
 
 # Prepare transition
 PLANNING_STATUS_OPTIONS: tuple[str, ...] = ("planning",)
-PLANNER_FIELD_NAME = "Needs Action From"
-PLANNER_FIELD_VALUE = "PLANNER"
 
 # Project field transition
 REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
-REVIEWER_FIELD_NAME = "Needs Action From"
-REVIEWER_FIELD_VALUE = "REVIEWER"
 
 ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -742,7 +742,7 @@ class TestTransitionProjectFields:
 
         assert "not in any project" in caplog.text
 
-    def test_updates_status_and_action_fields(self, caplog: pytest.LogCaptureFixture):
+    def test_updates_status_field(self, caplog: pytest.LogCaptureFixture):
         nodes = [
             {
                 "id": "item-1",
@@ -756,13 +756,6 @@ class TestTransitionProjectFields:
                             {"id": "opt-review", "name": "in-review"},
                         ],
                     },
-                    "actionField": {
-                        "id": "field-action",
-                        "options": [
-                            {"id": "opt-dev", "name": "DEVELOPER"},
-                            {"id": "opt-rev", "name": "REVIEWER"},
-                        ],
-                    },
                 },
             }
         ]
@@ -773,12 +766,11 @@ class TestTransitionProjectFields:
 
         with (
             caplog.at_level("INFO", logger="askcc.functions"),
-            patch("askcc.functions.subprocess.run", side_effect=[query_result, mutation_result, mutation_result]),
+            patch("askcc.functions.subprocess.run", side_effect=[query_result, mutation_result]),
         ):
             _transition_project_fields("/usr/bin/gh", "owner", "repo", 42)
 
         assert "Updated 'Status' in project 'My Board'" in caplog.text
-        assert "Updated 'Needs Action From' in project 'My Board'" in caplog.text
 
     def test_skips_missing_fields(self, caplog: pytest.LogCaptureFixture):
         nodes = [
@@ -788,7 +780,6 @@ class TestTransitionProjectFields:
                     "id": "proj-1",
                     "title": "Simple Board",
                     "statusField": None,
-                    "actionField": None,
                 },
             }
         ]
@@ -815,7 +806,6 @@ class TestTransitionProjectFields:
                         "id": "field-status",
                         "options": [{"id": "opt-todo", "name": "Todo"}, {"id": "opt-done", "name": "Done"}],
                     },
-                    "actionField": None,
                 },
             }
         ]
@@ -962,8 +952,6 @@ class TestTransitionIssueToPlanningIntegration:
             "askcc-cli",
             42,
             status_options=("planning",),
-            action_field_value="PLANNER",
-            action_field_name="Needs Action From",
         )
 
 


### PR DESCRIPTION
## Summary
- Remove the deprecated `Needs Action From` project field support that caused warnings on every run when the field doesn't exist in the target GitHub project
- Remove `actionField` from the GraphQL query, related constants, function parameters, and test fixtures

Closes #49

## Test plan
- [x] All 96 existing tests pass
- [x] Linting clean