### PR TITLE
:bug: Fix label swap to prevent orphaned issues (#48)

### DIFF
--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -432,17 +432,32 @@ def append_usage_to_last_comment(github_issue_url: str, usage: dict) -> None:
 
 
 def _swap_issue_labels(gh: str, repo_nwo: str, issue_number: int, *, remove: str, add: str) -> None:
-    """Remove one label and add another on a GitHub issue. Warns on failure."""
+    """Remove one label and add another on a GitHub issue.
+
+    Adds the new label first, then removes the old one only on success.
+    This prevents the issue from being left with no label if the target label doesn't exist.
+    """
     try:
         subprocess.run(  # noqa: S603
-            [gh, "issue", "edit", str(issue_number), "-R", repo_nwo, "--remove-label", remove, "--add-label", add],
+            [gh, "issue", "edit", str(issue_number), "-R", repo_nwo, "--add-label", add],
             capture_output=True,
             text=True,
             check=True,
         )
-        logger.info("Transitioned labels: -%s +%s on issue #%d", remove, add, issue_number)
     except subprocess.CalledProcessError as exc:
-        logger.warning("Failed to transition labels on issue #%d: %s", issue_number, exc.stderr)
+        logger.warning("Failed to add label '%s' on issue #%d: %s", add, issue_number, exc.stderr)
+        return
+    try:
+        subprocess.run(  # noqa: S603
+            [gh, "issue", "edit", str(issue_number), "-R", repo_nwo, "--remove-label", remove],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Failed to remove label '%s' on issue #%d: %s", remove, issue_number, exc.stderr)
+        return
+    logger.info("Transitioned labels: -%s +%s on issue #%d", remove, add, issue_number)
 
 
 def _find_option_id(options: list[dict], target_names: tuple[str, ...]) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.1.26"
+version = "0.1.27"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -709,23 +709,41 @@ class TestSwapIssueLabels:
         ):
             _swap_issue_labels("/usr/bin/gh", "owner/repo", 42, remove="action:develop", add="action:review")
 
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
-        assert "--remove-label" in cmd
-        assert "--add-label" in cmd
+        assert mock_run.call_count == 2
+        add_cmd = mock_run.call_args_list[0][0][0]
+        remove_cmd = mock_run.call_args_list[1][0][0]
+        assert "--add-label" in add_cmd
+        assert "--remove-label" not in add_cmd
+        assert "--remove-label" in remove_cmd
+        assert "--add-label" not in remove_cmd
         assert "Transitioned labels" in caplog.text
 
-    def test_failure_warns(self, caplog: pytest.LogCaptureFixture):
+    def test_add_failure_skips_remove(self, caplog: pytest.LogCaptureFixture):
         with (
             caplog.at_level("WARNING", logger="askcc.functions"),
             patch(
                 "askcc.functions.subprocess.run",
                 side_effect=subprocess.CalledProcessError(1, "gh", stderr="label not found"),
-            ),
+            ) as mock_run,
         ):
             _swap_issue_labels("/usr/bin/gh", "owner/repo", 42, remove="action:develop", add="action:review")
 
-        assert "Failed to transition labels" in caplog.text
+        mock_run.assert_called_once()  # only the add call, remove never attempted
+        assert "Failed to add label" in caplog.text
+
+    def test_remove_failure_warns(self, caplog: pytest.LogCaptureFixture):
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            caplog.at_level("WARNING", logger="askcc.functions"),
+            patch(
+                "askcc.functions.subprocess.run",
+                side_effect=[ok, subprocess.CalledProcessError(1, "gh", stderr="label not found")],
+            ) as mock_run,
+        ):
+            _swap_issue_labels("/usr/bin/gh", "owner/repo", 42, remove="action:develop", add="action:review")
+
+        assert mock_run.call_count == 2
+        assert "Failed to remove label" in caplog.text
 
 
 class TestTransitionProjectFields:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Split `_swap_issue_labels` into two sequential `gh` calls: add the target label first, then remove the source label only if the add succeeds
- Prevents issues from losing their `action:` label when the target label doesn't exist in the repo
- Bumps version to 0.1.27

Fixes #48

## Test plan

- [x] `test_success` — verifies both add and remove calls happen in correct order
- [x] `test_add_failure_skips_remove` — confirms remove is never attempted when add fails
- [x] `test_remove_failure_warns` — covers add succeeds but remove fails
- [x] Full test suite passes (97 tests)