### PR TITLE
:sparkles: Enforce red/green TDD in DEVELOP prompt (closes #68)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -181,8 +181,18 @@ If the label is present, a decision is pending — stop immediately without post
 Implementation:
 - Read the issue's planned implementation (in comments) before writing code.
 - Conform to the project's existing style, structure, and conventions.
-- Write tests for every new or changed behavior.
 - Make focused, minimal changes — do not refactor unrelated code.
+
+Testing methodology — red/green TDD (non-negotiable):
+- RED: write a failing test that captures the required behavior. Run it and confirm it fails \
+for the right reason. Paste the failing output into your working notes.
+- GREEN: write the minimum code needed to pass the test. No extra features, no speculative \
+abstractions, no "while I'm here" changes.
+- REFACTOR: only if there is clear duplication or unclear naming. Keep tests green throughout.
+- Tests must assert on observable inputs/outputs or side effects — never by re-invoking the \
+implementation's own logic to compute the expected value.
+- Do NOT proceed from RED to GREEN without a confirmed failing run.
+- Commit tests and implementation together.
 
 Decisions:
 - When you make a judgment call not specified in the plan, document it as: \
@@ -202,6 +212,8 @@ Common commands: `uv run pytest`, `uv run ruff check`, `uv run pyright`, `npm te
   ```
 
 Anti-rationalization — do not take these shortcuts:
+- "I'll write the test after, it's faster" — Tests written after implementation verify the code, \
+not the requirement. Always RED before GREEN.
 - "Tests aren't needed for this small change" — Small changes cause the majority of regressions. \
 Every behavioral change requires a test.
 - "I'll skip linting, the CI will catch it" — Catching errors locally is cheaper than a failed CI round-trip. \

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -9,7 +9,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from askcc.cli import main
-from askcc.definitions import AGENT_CONFIGS, AgentAction, AgentConfig, SupportedLanguage
+from askcc.definitions import (
+    AGENT_CONFIGS,
+    DEVELOP_AGENT_PROMPT,
+    AgentAction,
+    AgentConfig,
+    SupportedLanguage,
+)
 from askcc.functions import (
     CheckResult,
     VerificationResult,
@@ -227,6 +233,37 @@ class TestLoadAgentConfig:
 
         with pytest.raises(ValueError, match="missing required variable"):
             load_agent_config(AgentAction.PLAN)
+
+
+class TestDevelopPromptTddContent:
+    def test_includes_red_green_tdd_block(self):
+        assert "Testing methodology — red/green TDD (non-negotiable):" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_red_phase_with_failure_confirmation(self):
+        assert "RED:" in DEVELOP_AGENT_PROMPT
+        assert "confirm it fails" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_green_phase_with_minimum_code(self):
+        assert "GREEN:" in DEVELOP_AGENT_PROMPT
+        assert "minimum code" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_refactor_phase(self):
+        assert "REFACTOR:" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_phase_gate_blocking_red_to_green(self):
+        assert "Do NOT proceed from RED to GREEN without a confirmed failing run." in DEVELOP_AGENT_PROMPT
+
+    def test_includes_behavioral_assertion_rule(self):
+        assert "observable inputs/outputs or side effects" in DEVELOP_AGENT_PROMPT
+
+    def test_requires_committing_tests_with_implementation(self):
+        assert "Commit tests and implementation together." in DEVELOP_AGENT_PROMPT
+
+    def test_anti_rationalization_includes_tests_after_entry(self):
+        assert "I'll write the test after, it's faster" in DEVELOP_AGENT_PROMPT
+
+    def test_removes_legacy_write_tests_line(self):
+        assert "Write tests for every new or changed behavior" not in DEVELOP_AGENT_PROMPT
 
 
 class TestWritePromptContent:


### PR DESCRIPTION
## Summary
- Replaces the soft `Write tests for every new or changed behavior` bullet in `DEVELOP_AGENT_PROMPT` with a non-negotiable red/green TDD block (RED, GREEN, REFACTOR), behavioral-assertion rule, and a phase gate forbidding the move from RED to GREEN without a confirmed failing run.
- Adds an anti-rationalization entry rejecting `"I'll write the test after, it's faster"`.
- Adds `TestDevelopPromptTddContent` covering each new requirement (TDD discipline applied to this change itself — tests written first, confirmed RED, then implementation made them GREEN).

Closes #68

## Key Flows

```mermaid
flowchart TD
    A[Agent receives DEVELOP task] --> B[Read planned implementation]
    B --> C[RED: write failing test]
    C --> D{test fails for right reason?}
    D -- no --> C
    D -- yes --> E[GREEN: minimum code to pass]
    E --> F{test passes?}
    F -- no --> E
    F -- yes --> G[REFACTOR if duplication/naming unclear]
    G --> H[Commit tests + implementation together]
```

## Verification
- `uv run pytest` — passed (123 tests)
- `uv run ruff check` — passed (All checks passed!)
- `uv run pyright` — passed (0 errors, 0 warnings)