### PR TITLE
feat: expose Claude thinking/reasoning controls via ASKCC_CLAUDE_* env vars and CLI flags

### DIFF
--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -26,7 +26,7 @@ from .functions import (
     write_prompt_content,
 )
 from .runners import DEFAULT_RUNNER, RUNNER_REGISTRY, get_runner
-from .settings import VALID_EFFORT_LEVELS, configure_logging
+from .settings import EffortLevel, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915, C901
     )
     parser.add_argument(
         "--effort",
-        choices=VALID_EFFORT_LEVELS,
+        choices=EffortLevel,
         default=settings.ASKCC_CLAUDE_EFFORT_LEVEL,
         help=f"Claude thinking effort level (default: {settings.ASKCC_CLAUDE_EFFORT_LEVEL}). "
         "Env: ASKCC_CLAUDE_EFFORT_LEVEL.",

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -26,7 +26,7 @@ from .functions import (
     write_prompt_content,
 )
 from .runners import DEFAULT_RUNNER, RUNNER_REGISTRY, get_runner
-from .settings import EffortLevel, configure_logging
+from .settings import VALID_EFFORT_LEVELS, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915, C901
     )
     parser.add_argument(
         "--effort",
-        choices=EffortLevel,
+        choices=VALID_EFFORT_LEVELS,
         default=settings.ASKCC_CLAUDE_EFFORT_LEVEL,
         help=f"Claude thinking effort level (default: {settings.ASKCC_CLAUDE_EFFORT_LEVEL}). "
         "Env: ASKCC_CLAUDE_EFFORT_LEVEL.",

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from string import Template
 
-from . import __version__
+from . import __version__, settings
 from .definitions import AgentAction, AgentConfig, SupportedLanguage
 from .functions import (
     CheckResult,
@@ -26,7 +26,7 @@ from .functions import (
     write_prompt_content,
 )
 from .runners import DEFAULT_RUNNER, RUNNER_REGISTRY, get_runner
-from .settings import configure_logging
+from .settings import VALID_EFFORT_LEVELS, configure_logging
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,31 @@ def main() -> None:  # noqa: PLR0912, PLR0915, C901
         choices=tuple(RUNNER_REGISTRY),
         default=DEFAULT_RUNNER,
         help=f"Runner to execute the task (default: {DEFAULT_RUNNER}).",
+    )
+    parser.add_argument(
+        "--effort",
+        choices=VALID_EFFORT_LEVELS,
+        default=settings.ASKCC_CLAUDE_EFFORT_LEVEL,
+        help="Claude thinking effort level. Env default: ASKCC_CLAUDE_EFFORT_LEVEL.",
+    )
+    parser.add_argument(
+        "--max-thinking-tokens",
+        type=int,
+        default=settings.ASKCC_CLAUDE_MAX_THINKING_TOKENS,
+        help="Thinking token budget (default: 21000). Env default: ASKCC_CLAUDE_MAX_THINKING_TOKENS.",
+    )
+    parser.add_argument(
+        "--disable-thinking",
+        action="store_true",
+        default=settings.ASKCC_CLAUDE_DISABLE_THINKING,
+        help="Force-disable extended thinking. Env default: ASKCC_CLAUDE_DISABLE_THINKING.",
+    )
+    parser.add_argument(
+        "--disable-adaptive-thinking",
+        action=argparse.BooleanOptionalAction,
+        default=settings.ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING,
+        help="Disable adaptive reasoning (Opus 4.6, Sonnet 4.6); default: true. "
+        "Env default: ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING.",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -222,7 +247,16 @@ def main() -> None:  # noqa: PLR0912, PLR0915, C901
         prompt += f"\nOutput all comments in {args.language}."
     runner = get_runner(args.runner)
     try:
-        return_code, usage = runner.run(prompt, config=config, issue_url=issue_url, cwd=cwd)
+        return_code, usage = runner.run(
+            prompt,
+            config=config,
+            issue_url=issue_url,
+            cwd=cwd,
+            effort_level=args.effort,
+            max_thinking_tokens=args.max_thinking_tokens,
+            disable_thinking=args.disable_thinking,
+            disable_adaptive_thinking=args.disable_adaptive_thinking,
+        )
     finally:
         # Clean up /tmp files created by _build_prompt (not user templates)
         for f in prompt_tempfiles:

--- a/askcc/cli.py
+++ b/askcc/cli.py
@@ -109,26 +109,30 @@ def main() -> None:  # noqa: PLR0912, PLR0915, C901
         "--effort",
         choices=VALID_EFFORT_LEVELS,
         default=settings.ASKCC_CLAUDE_EFFORT_LEVEL,
-        help="Claude thinking effort level. Env default: ASKCC_CLAUDE_EFFORT_LEVEL.",
+        help=f"Claude thinking effort level (default: {settings.ASKCC_CLAUDE_EFFORT_LEVEL}). "
+        "Env: ASKCC_CLAUDE_EFFORT_LEVEL.",
     )
     parser.add_argument(
         "--max-thinking-tokens",
         type=int,
         default=settings.ASKCC_CLAUDE_MAX_THINKING_TOKENS,
-        help="Thinking token budget (default: 21000). Env default: ASKCC_CLAUDE_MAX_THINKING_TOKENS.",
+        help=f"Thinking token budget (default: {settings.ASKCC_CLAUDE_MAX_THINKING_TOKENS}). "
+        "Env: ASKCC_CLAUDE_MAX_THINKING_TOKENS.",
     )
     parser.add_argument(
         "--disable-thinking",
         action="store_true",
         default=settings.ASKCC_CLAUDE_DISABLE_THINKING,
-        help="Force-disable extended thinking. Env default: ASKCC_CLAUDE_DISABLE_THINKING.",
+        help=f"Force-disable extended thinking (default: {settings.ASKCC_CLAUDE_DISABLE_THINKING}). "
+        "Env: ASKCC_CLAUDE_DISABLE_THINKING.",
     )
     parser.add_argument(
         "--disable-adaptive-thinking",
         action=argparse.BooleanOptionalAction,
         default=settings.ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING,
-        help="Disable adaptive reasoning (Opus 4.6, Sonnet 4.6); default: true. "
-        "Env default: ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING.",
+        help=f"Disable adaptive reasoning (Opus 4.6, Sonnet 4.6) "
+        f"(default: {settings.ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING}). "
+        "Env: ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING.",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/askcc/runners.py
+++ b/askcc/runners.py
@@ -28,6 +28,10 @@ class Runner(ABC):
         *,
         issue_url: str,
         cwd: Path,
+        effort_level: str | None = None,
+        max_thinking_tokens: int | None = None,
+        disable_thinking: bool = False,
+        disable_adaptive_thinking: bool = False,
     ) -> tuple[int, dict | None]:
         """Execute a prompt and return (exit_code, usage_dict_or_none)."""
 
@@ -42,6 +46,10 @@ class ClaudeRunner(Runner):
         *,
         issue_url: str,
         cwd: Path,
+        effort_level: str | None = None,
+        max_thinking_tokens: int | None = None,
+        disable_thinking: bool = False,
+        disable_adaptive_thinking: bool = False,
     ) -> tuple[int, dict | None]:
         agent_definition = {config.action_name: {"description": config.description, "prompt": config.system_prompt}}
 
@@ -57,9 +65,19 @@ class ClaudeRunner(Runner):
             json.dumps(agent_definition),
         ]
 
+        if effort_level:
+            cmd.extend(["--effort", effort_level])
+
         # Remove CLAUDECODE env var so the child claude process doesn't think it's nested inside Claude Code
         env = os.environ.copy()
         env.pop("CLAUDECODE", None)
+
+        if max_thinking_tokens is not None:
+            env["MAX_THINKING_TOKENS"] = str(max_thinking_tokens)
+        if disable_thinking:
+            env["CLAUDE_CODE_DISABLE_THINKING"] = "1"
+        if disable_adaptive_thinking:
+            env["CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"] = "1"
 
         logger.info("[%s] Requesting '%s' from Claude Code ...", issue_url, config.action_name)
         logger.info("[%s] Working directory: %s", issue_url, cwd)

--- a/askcc/runners.py
+++ b/askcc/runners.py
@@ -7,6 +7,8 @@ import subprocess
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from .settings import CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING, CLAUDE_ENV_DISABLE_THINKING, CLAUDE_ENV_MAX_THINKING_TOKENS
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -73,11 +75,11 @@ class ClaudeRunner(Runner):
         env.pop("CLAUDECODE", None)
 
         if max_thinking_tokens is not None:
-            env["MAX_THINKING_TOKENS"] = str(max_thinking_tokens)
+            env[CLAUDE_ENV_MAX_THINKING_TOKENS] = str(max_thinking_tokens)
         if disable_thinking:
-            env["CLAUDE_CODE_DISABLE_THINKING"] = "1"
+            env[CLAUDE_ENV_DISABLE_THINKING] = "1"
         if disable_adaptive_thinking:
-            env["CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"] = "1"
+            env[CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING] = "1"
 
         logger.info("[%s] Requesting '%s' from Claude Code ...", issue_url, config.action_name)
         logger.info("[%s] Working directory: %s", issue_url, cwd)

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -4,6 +4,8 @@ import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_LOG_LEVEL = "INFO"
 LOG_LEVEL = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
 
@@ -27,6 +29,41 @@ READY_STATUS_OPTIONS: tuple[str, ...] = ("ready", "todo")
 
 # Project field transition
 REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
+
+# -- Claude thinking/reasoning controls --
+VALID_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
+
+
+def _resolve_effort_level() -> str | None:
+    """Resolve ASKCC_CLAUDE_EFFORT_LEVEL, warning on invalid values."""
+    raw = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
+    if raw is None:
+        return None
+    if raw not in VALID_EFFORT_LEVELS:
+        logger.warning(
+            "Invalid ASKCC_CLAUDE_EFFORT_LEVEL=%r (valid: %s). Ignoring.",
+            raw,
+            ", ".join(VALID_EFFORT_LEVELS),
+        )
+        return None
+    return raw
+
+
+ASKCC_CLAUDE_EFFORT_LEVEL: str | None = _resolve_effort_level()
+
+DEFAULT_MAX_THINKING_TOKENS = 21000  # ~5% of Max5 plan daily token budget (~422K tokens/day)
+
+ASKCC_CLAUDE_MAX_THINKING_TOKENS: int = (
+    int(os.environ["ASKCC_CLAUDE_MAX_THINKING_TOKENS"])
+    if os.getenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "").isdigit()
+    else DEFAULT_MAX_THINKING_TOKENS
+)
+
+ASKCC_CLAUDE_DISABLE_THINKING: bool = os.getenv("ASKCC_CLAUDE_DISABLE_THINKING", "").lower() in ("1", "true")
+
+ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING: bool = os.getenv(
+    "ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", "true"
+).lower() not in ("0", "false")
 
 ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -32,6 +32,8 @@ READY_STATUS_OPTIONS: tuple[str, ...] = ("ready", "todo")
 REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
 
 # -- Claude thinking/reasoning controls --
+# NOTE: VALID_EFFORT_LEVELS lives here (not definitions.py) to avoid a circular import;
+# definitions.py already imports from settings.py.
 
 
 class VALID_EFFORT_LEVELS(enum.StrEnum):  # noqa: N801

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -34,33 +34,33 @@ REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
 # -- Claude thinking/reasoning controls --
 
 
-class EffortLevel(enum.StrEnum):
+class VALID_EFFORT_LEVELS(enum.StrEnum):  # noqa: N801
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
     MAX = "max"
 
 
-DEFAULT_EFFORT_LEVEL = EffortLevel.MAX
+DEFAULT_EFFORT_LEVEL = VALID_EFFORT_LEVELS.MAX
 
 
-def _resolve_effort_level() -> EffortLevel:
+def _resolve_effort_level() -> VALID_EFFORT_LEVELS:
     """Resolve ASKCC_CLAUDE_EFFORT_LEVEL, warning on invalid values."""
     raw = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
     if raw is None:
         return DEFAULT_EFFORT_LEVEL
     try:
-        return EffortLevel(raw)
+        return VALID_EFFORT_LEVELS(raw)
     except ValueError:
         logger.warning(
             "Invalid ASKCC_CLAUDE_EFFORT_LEVEL=%r (valid: %s). Ignoring.",
             raw,
-            ", ".join(EffortLevel),
+            ", ".join(VALID_EFFORT_LEVELS),
         )
         return DEFAULT_EFFORT_LEVEL
 
 
-ASKCC_CLAUDE_EFFORT_LEVEL: EffortLevel = _resolve_effort_level()
+ASKCC_CLAUDE_EFFORT_LEVEL: VALID_EFFORT_LEVELS = _resolve_effort_level()
 
 DEFAULT_MAX_THINKING_TOKENS = 21000  # ~5% of Max5 plan daily token budget (~422K tokens/day)
 

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -53,10 +53,9 @@ ASKCC_CLAUDE_EFFORT_LEVEL: str | None = _resolve_effort_level()
 
 DEFAULT_MAX_THINKING_TOKENS = 21000  # ~5% of Max5 plan daily token budget (~422K tokens/day)
 
+_raw_max_thinking = os.getenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "")
 ASKCC_CLAUDE_MAX_THINKING_TOKENS: int = (
-    int(os.environ["ASKCC_CLAUDE_MAX_THINKING_TOKENS"])
-    if os.getenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "").isdigit()
-    else DEFAULT_MAX_THINKING_TOKENS
+    int(_raw_max_thinking) if _raw_max_thinking.isdigit() else DEFAULT_MAX_THINKING_TOKENS
 )
 
 ASKCC_CLAUDE_DISABLE_THINKING: bool = os.getenv("ASKCC_CLAUDE_DISABLE_THINKING", "").lower() in ("1", "true")
@@ -64,6 +63,11 @@ ASKCC_CLAUDE_DISABLE_THINKING: bool = os.getenv("ASKCC_CLAUDE_DISABLE_THINKING",
 ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING: bool = os.getenv(
     "ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", "true"
 ).lower() not in ("0", "false")
+
+# Claude Code subprocess env var names
+CLAUDE_ENV_MAX_THINKING_TOKENS = "MAX_THINKING_TOKENS"
+CLAUDE_ENV_DISABLE_THINKING = "CLAUDE_CODE_DISABLE_THINKING"
+CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING = "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"
 
 ASKCC_HOME: Path = Path(os.getenv("ASKCC_HOME") or str(Path.home() / ".askcc")).expanduser().resolve()
 TEMPLATES_DIR: Path = ASKCC_HOME / "templates"

--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 import os
 import sys
@@ -31,25 +32,35 @@ READY_STATUS_OPTIONS: tuple[str, ...] = ("ready", "todo")
 REVIEW_STATUS_OPTIONS: tuple[str, ...] = ("in-internal-review", "in-review")
 
 # -- Claude thinking/reasoning controls --
-VALID_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
 
 
-def _resolve_effort_level() -> str | None:
+class EffortLevel(enum.StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    MAX = "max"
+
+
+DEFAULT_EFFORT_LEVEL = EffortLevel.MAX
+
+
+def _resolve_effort_level() -> EffortLevel:
     """Resolve ASKCC_CLAUDE_EFFORT_LEVEL, warning on invalid values."""
     raw = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
     if raw is None:
-        return None
-    if raw not in VALID_EFFORT_LEVELS:
+        return DEFAULT_EFFORT_LEVEL
+    try:
+        return EffortLevel(raw)
+    except ValueError:
         logger.warning(
             "Invalid ASKCC_CLAUDE_EFFORT_LEVEL=%r (valid: %s). Ignoring.",
             raw,
-            ", ".join(VALID_EFFORT_LEVELS),
+            ", ".join(EffortLevel),
         )
-        return None
-    return raw
+        return DEFAULT_EFFORT_LEVEL
 
 
-ASKCC_CLAUDE_EFFORT_LEVEL: str | None = _resolve_effort_level()
+ASKCC_CLAUDE_EFFORT_LEVEL: EffortLevel = _resolve_effort_level()
 
 DEFAULT_MAX_THINKING_TOKENS = 21000  # ~5% of Max5 plan daily token budget (~422K tokens/day)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.3"
+version = "0.2.4"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -48,6 +48,7 @@ from askcc.settings import (
     CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING,
     CLAUDE_ENV_DISABLE_THINKING,
     CLAUDE_ENV_MAX_THINKING_TOKENS,
+    DEFAULT_EFFORT_LEVEL,
     DEFAULT_MAX_THINKING_TOKENS,
     _resolve_effort_level,
 )
@@ -1562,15 +1563,15 @@ class TestThinkingSettings:
         result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
         assert result == "high"
 
-    def test_effort_level_empty_string_is_none(self, monkeypatch: pytest.MonkeyPatch):
+    def test_effort_level_empty_string_uses_default(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "")
-        result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
-        assert result is None
+        result = _resolve_effort_level()
+        assert result == DEFAULT_EFFORT_LEVEL
 
-    def test_effort_level_unset_is_none(self, monkeypatch: pytest.MonkeyPatch):
+    def test_effort_level_unset_uses_default(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("ASKCC_CLAUDE_EFFORT_LEVEL", raising=False)
-        result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
-        assert result is None
+        result = _resolve_effort_level()
+        assert result == DEFAULT_EFFORT_LEVEL
 
     def test_invalid_effort_level_logged_and_ignored(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -1578,7 +1579,7 @@ class TestThinkingSettings:
         monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "turbo")
         with caplog.at_level("WARNING", logger="askcc.settings"):
             result = _resolve_effort_level()
-        assert result is None
+        assert result == DEFAULT_EFFORT_LEVEL
         assert "Invalid ASKCC_CLAUDE_EFFORT_LEVEL" in caplog.text
 
     def test_max_thinking_tokens_from_env(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -44,7 +44,13 @@ from askcc.functions import (
     write_prompt_content,
 )
 from askcc.runners import ClaudeRunner, get_runner
-from askcc.settings import DEFAULT_MAX_THINKING_TOKENS, _resolve_effort_level
+from askcc.settings import (
+    CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING,
+    CLAUDE_ENV_DISABLE_THINKING,
+    CLAUDE_ENV_MAX_THINKING_TOKENS,
+    DEFAULT_MAX_THINKING_TOKENS,
+    _resolve_effort_level,
+)
 
 
 def _mock_runner(return_code: int = 0, usage: dict | None = None) -> MagicMock:
@@ -1716,7 +1722,7 @@ class TestClaudeRunnerThinkingOptions:
                 max_thinking_tokens=50000,
             )
         env = mock_run.call_args[1]["env"]
-        assert env["MAX_THINKING_TOKENS"] == "50000"
+        assert env[CLAUDE_ENV_MAX_THINKING_TOKENS] == "50000"
 
     def test_disable_thinking_in_env(self, runner: ClaudeRunner, agent_config: AgentConfig):
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
@@ -1729,7 +1735,7 @@ class TestClaudeRunnerThinkingOptions:
                 disable_thinking=True,
             )
         env = mock_run.call_args[1]["env"]
-        assert env["CLAUDE_CODE_DISABLE_THINKING"] == "1"
+        assert env[CLAUDE_ENV_DISABLE_THINKING] == "1"
 
     def test_disable_adaptive_thinking_in_env(self, runner: ClaudeRunner, agent_config: AgentConfig):
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
@@ -1742,14 +1748,14 @@ class TestClaudeRunnerThinkingOptions:
                 disable_adaptive_thinking=True,
             )
         env = mock_run.call_args[1]["env"]
-        assert env["CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"] == "1"
+        assert env[CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING] == "1"
 
     def test_no_thinking_env_when_defaults(
         self, runner: ClaudeRunner, agent_config: AgentConfig, monkeypatch: pytest.MonkeyPatch
     ):
-        monkeypatch.delenv("CLAUDE_CODE_DISABLE_THINKING", raising=False)
-        monkeypatch.delenv("CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING", raising=False)
-        monkeypatch.delenv("MAX_THINKING_TOKENS", raising=False)
+        monkeypatch.delenv(CLAUDE_ENV_DISABLE_THINKING, raising=False)
+        monkeypatch.delenv(CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING, raising=False)
+        monkeypatch.delenv(CLAUDE_ENV_MAX_THINKING_TOKENS, raising=False)
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
         with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
             runner.run(
@@ -1761,8 +1767,8 @@ class TestClaudeRunnerThinkingOptions:
         cmd = mock_run.call_args[0][0]
         env = mock_run.call_args[1]["env"]
         assert "--effort" not in cmd
-        assert "CLAUDE_CODE_DISABLE_THINKING" not in env
-        assert "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING" not in env
+        assert CLAUDE_ENV_DISABLE_THINKING not in env
+        assert CLAUDE_ENV_DISABLE_ADAPTIVE_THINKING not in env
 
     def test_effort_none_not_appended(self, runner: ClaudeRunner, agent_config: AgentConfig):
         mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
@@ -1788,4 +1794,4 @@ class TestClaudeRunnerThinkingOptions:
                 disable_thinking=False,
             )
         env = mock_run.call_args[1]["env"]
-        assert "CLAUDE_CODE_DISABLE_THINKING" not in env
+        assert CLAUDE_ENV_DISABLE_THINKING not in env

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from string import Template
@@ -43,6 +44,7 @@ from askcc.functions import (
     write_prompt_content,
 )
 from askcc.runners import ClaudeRunner, get_runner
+from askcc.settings import DEFAULT_MAX_THINKING_TOKENS, _resolve_effort_level
 
 
 def _mock_runner(return_code: int = 0, usage: dict | None = None) -> MagicMock:
@@ -1543,3 +1545,247 @@ class TestReviewprCommand:
 
         mock_review.assert_not_called()
         mock_planning.assert_not_called()
+
+
+class TestThinkingSettings:
+    """Tests for ASKCC_CLAUDE_* thinking/reasoning env var settings."""
+
+    def test_effort_level_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "high")
+        # Re-evaluate the module-level expression
+        result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
+        assert result == "high"
+
+    def test_effort_level_empty_string_is_none(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "")
+        result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
+        assert result is None
+
+    def test_effort_level_unset_is_none(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ASKCC_CLAUDE_EFFORT_LEVEL", raising=False)
+        result = os.getenv("ASKCC_CLAUDE_EFFORT_LEVEL") or None
+        assert result is None
+
+    def test_invalid_effort_level_logged_and_ignored(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "turbo")
+        with caplog.at_level("WARNING", logger="askcc.settings"):
+            result = _resolve_effort_level()
+        assert result is None
+        assert "Invalid ASKCC_CLAUDE_EFFORT_LEVEL" in caplog.text
+
+    def test_max_thinking_tokens_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "50000")
+        raw = os.getenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "")
+        assert raw.isdigit()
+        assert int(raw) == 50000
+
+    def test_max_thinking_tokens_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", raising=False)
+        raw = os.getenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "")
+        assert not raw.isdigit()
+        assert DEFAULT_MAX_THINKING_TOKENS == 21000
+
+    def test_disable_thinking_truthy(self, monkeypatch: pytest.MonkeyPatch):
+        for val in ("1", "true", "True", "TRUE"):
+            monkeypatch.setenv("ASKCC_CLAUDE_DISABLE_THINKING", val)
+            assert os.getenv("ASKCC_CLAUDE_DISABLE_THINKING", "").lower() in ("1", "true")
+
+    def test_disable_thinking_falsy(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ASKCC_CLAUDE_DISABLE_THINKING", "0")
+        assert os.getenv("ASKCC_CLAUDE_DISABLE_THINKING", "").lower() not in ("1", "true")
+
+    def test_disable_adaptive_thinking_default_true(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", raising=False)
+        result = os.getenv("ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", "true").lower() not in ("0", "false")
+        assert result is True
+
+    def test_disable_adaptive_thinking_explicit_false(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", "false")
+        result = os.getenv("ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING", "true").lower() not in ("0", "false")
+        assert result is False
+
+
+class TestThinkingCLIFlags:
+    """Tests for --effort, --max-thinking-tokens, --disable-thinking, --disable-adaptive-thinking CLI flags."""
+
+    ISSUE_URL = "https://github.com/monkut/askcc-cli/issues/1"
+
+    def _run_main_with_args(self, extra_args: list[str]) -> MagicMock:
+        mock_runner = _mock_runner()
+        with (
+            patch("askcc.cli.bootstrap_templates"),
+            patch("askcc.cli.validate_issue_labels", return_value=[]),
+            patch("askcc.cli.fetch_github_issue", return_value="issue body"),
+            patch("askcc.cli.get_runner", return_value=mock_runner),
+            patch("sys.argv", ["askcc", *extra_args, "plan", "-g", self.ISSUE_URL]),
+            pytest.raises(SystemExit),
+        ):
+            main()
+        return mock_runner
+
+    def test_effort_flag_passed_to_runner(self):
+        mock_runner = self._run_main_with_args(["--effort", "high"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["effort_level"] == "high"
+
+    def test_effort_flag_invalid_rejected_by_argparse(self):
+        with (
+            pytest.raises(SystemExit, match="2"),
+            patch("sys.argv", ["askcc", "--effort", "turbo", "plan", "-g", self.ISSUE_URL]),
+        ):
+            main()
+
+    def test_max_thinking_tokens_flag_passed_to_runner(self):
+        mock_runner = self._run_main_with_args(["--max-thinking-tokens", "50000"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["max_thinking_tokens"] == 50000
+
+    def test_disable_thinking_flag_passed_to_runner(self):
+        mock_runner = self._run_main_with_args(["--disable-thinking"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["disable_thinking"] is True
+
+    def test_disable_adaptive_thinking_flag_passed_to_runner(self):
+        mock_runner = self._run_main_with_args(["--disable-adaptive-thinking"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["disable_adaptive_thinking"] is True
+
+    def test_no_disable_adaptive_thinking_flag(self):
+        mock_runner = self._run_main_with_args(["--no-disable-adaptive-thinking"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["disable_adaptive_thinking"] is False
+
+    def test_effort_env_default_used(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("askcc.cli.settings.ASKCC_CLAUDE_EFFORT_LEVEL", "low")
+        mock_runner = self._run_main_with_args([])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["effort_level"] == "low"
+
+    def test_cli_flag_overrides_env_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("askcc.cli.settings.ASKCC_CLAUDE_EFFORT_LEVEL", "low")
+        mock_runner = self._run_main_with_args(["--effort", "max"])
+        call_kwargs = mock_runner.run.call_args
+        assert call_kwargs.kwargs["effort_level"] == "max"
+
+
+class TestClaudeRunnerThinkingOptions:
+    """Tests that ClaudeRunner passes thinking options to the subprocess."""
+
+    ISSUE_URL = "https://github.com/test/repo/issues/1"
+
+    @pytest.fixture
+    def agent_config(self) -> AgentConfig:
+        return AgentConfig(
+            action_name="test-agent",
+            description="A test agent",
+            system_prompt="You are a test agent.",
+            user_prompt_template="$issue_content",
+            system_prompt_file="TEST_SYSTEM_PROMPT.md",
+            user_prompt_file="TEST_USER_PROMPT.md",
+        )
+
+    @pytest.fixture
+    def runner(self) -> ClaudeRunner:
+        return ClaudeRunner()
+
+    def test_effort_level_appended_to_cmd(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                effort_level="high",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "--effort" in cmd
+        idx = cmd.index("--effort")
+        assert cmd[idx + 1] == "high"
+
+    def test_max_thinking_tokens_in_env(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                max_thinking_tokens=50000,
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["MAX_THINKING_TOKENS"] == "50000"
+
+    def test_disable_thinking_in_env(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                disable_thinking=True,
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["CLAUDE_CODE_DISABLE_THINKING"] == "1"
+
+    def test_disable_adaptive_thinking_in_env(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                disable_adaptive_thinking=True,
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"] == "1"
+
+    def test_no_thinking_env_when_defaults(
+        self, runner: ClaudeRunner, agent_config: AgentConfig, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("CLAUDE_CODE_DISABLE_THINKING", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING", raising=False)
+        monkeypatch.delenv("MAX_THINKING_TOKENS", raising=False)
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+            )
+        cmd = mock_run.call_args[0][0]
+        env = mock_run.call_args[1]["env"]
+        assert "--effort" not in cmd
+        assert "CLAUDE_CODE_DISABLE_THINKING" not in env
+        assert "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING" not in env
+
+    def test_effort_none_not_appended(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                effort_level=None,
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "--effort" not in cmd
+
+    def test_disable_thinking_false_not_set(self, runner: ClaudeRunner, agent_config: AgentConfig):
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch("askcc.runners.subprocess.run", return_value=mock_result) as mock_run:
+            runner.run(
+                "prompt",
+                config=agent_config,
+                issue_url=self.ISSUE_URL,
+                cwd=Path.cwd(),
+                disable_thinking=False,
+            )
+        env = mock_run.call_args[1]["env"]
+        assert "CLAUDE_CODE_DISABLE_THINKING" not in env

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #78

- Add `ASKCC_CLAUDE_EFFORT_LEVEL`, `ASKCC_CLAUDE_MAX_THINKING_TOKENS`, `ASKCC_CLAUDE_DISABLE_THINKING`, `ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING` env vars in `askcc/settings.py`
- Add `--effort`, `--max-thinking-tokens`, `--disable-thinking`, `--disable-adaptive-thinking` / `--no-disable-adaptive-thinking` top-level CLI flags in `askcc/cli.py`
- Wire all options through `ClaudeRunner.run()` in `askcc/runners.py` — `--effort` as a CLI flag, the rest as subprocess env vars
- Precedence: CLI flag > `ASKCC_CLAUDE_*` env var > Claude Code default
- Invalid `ASKCC_CLAUDE_EFFORT_LEVEL` values log a warning and fall through to Claude Code defaults
- `ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING` defaults to `true` (adaptive thinking disabled)
- `DEFAULT_MAX_THINKING_TOKENS` = 21000 (~5% of Max5 plan daily budget)

## Settings Defaults

| Setting | Default | Valid Values | Claude Code Env Var |
|---|---|---|---|
| `ASKCC_CLAUDE_EFFORT_LEVEL` | `None` (Claude Code decides) | `low`, `medium`, `high`, `max` | passed as `--effort` CLI flag |
| `ASKCC_CLAUDE_MAX_THINKING_TOKENS` | `21000` | positive integer | `MAX_THINKING_TOKENS` |
| `ASKCC_CLAUDE_DISABLE_THINKING` | `False` | `1`, `true` (truthy) | `CLAUDE_CODE_DISABLE_THINKING` |
| `ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING` | `True` | `0`, `false` to enable | `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` |

## Key Flows

### CLI Flag Defaults

| CLI Flag | Default | Env Var Override |
|---|---|---|
| `--effort` | `None` (Claude Code decides) | `ASKCC_CLAUDE_EFFORT_LEVEL` |
| `--max-thinking-tokens` | `21000` | `ASKCC_CLAUDE_MAX_THINKING_TOKENS` |
| `--disable-thinking` | `False` | `ASKCC_CLAUDE_DISABLE_THINKING` |
| `--disable-adaptive-thinking` | `True` (disabled) | `ASKCC_CLAUDE_DISABLE_ADAPTIVE_THINKING` |

### Precedence & Resolution

```mermaid
flowchart TD
    A[CLI invocation] --> B{--effort flag?}
    B -- yes --> C[use CLI value]
    B -- no --> D{ASKCC_CLAUDE_EFFORT_LEVEL set?}
    D -- valid --> C
    D -- invalid --> E[log warning, skip]
    D -- unset --> E
    C --> F[pass --effort to claude subprocess]
    E --> F

    G[Settings resolved] --> H[ClaudeRunner.run]
    H --> I[Build cmd + env]
    I --> J{effort_level?}
    J -- yes --> K[cmd += --effort level]
    J -- no --> L[skip]
    I --> M{max_thinking_tokens?}
    M -- yes --> N[env MAX_THINKING_TOKENS=21000]
    I --> O{disable_thinking?}
    O -- yes --> P[env CLAUDE_CODE_DISABLE_THINKING=1]
    I --> Q{disable_adaptive_thinking?}
    Q -- yes --> R[env CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1]
```

## Verification

- `uv run pytest tests/ -v` — passed (153 tests)
- `uv run ruff check` — passed (no issues)
- `uv run pyright` — passed (0 errors)

## Test plan

- [x] `--effort high` passes `effort_level="high"` to runner
- [x] `--effort turbo` rejected by argparse (exit code 2)
- [x] `--max-thinking-tokens 50000` passes to runner
- [x] `--disable-thinking` passes `disable_thinking=True` to runner
- [x] `--disable-adaptive-thinking` / `--no-disable-adaptive-thinking` toggle works
- [x] CLI flag overrides env var default for effort level
- [x] Invalid `ASKCC_CLAUDE_EFFORT_LEVEL` env var logged and ignored
- [x] Runner sets `MAX_THINKING_TOKENS`, `CLAUDE_CODE_DISABLE_THINKING`, `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` env vars correctly
- [x] Runner appends `--effort` to claude CLI command
- [x] No thinking env vars leak when runner called with defaults