### PR TITLE
:sparkles: Add 'xhigh' effort level and default to it (refs #81)

### DIFF
--- a/askcc/settings.py
+++ b/askcc/settings.py
@@ -40,10 +40,11 @@ class VALID_EFFORT_LEVELS(enum.StrEnum):  # noqa: N801
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    XHIGH = "xhigh"
     MAX = "max"
 
 
-DEFAULT_EFFORT_LEVEL = VALID_EFFORT_LEVELS.MAX
+DEFAULT_EFFORT_LEVEL = VALID_EFFORT_LEVELS.XHIGH
 
 
 def _resolve_effort_level() -> VALID_EFFORT_LEVELS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.4"
+version = "0.2.5"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -50,6 +50,7 @@ from askcc.settings import (
     CLAUDE_ENV_MAX_THINKING_TOKENS,
     DEFAULT_EFFORT_LEVEL,
     DEFAULT_MAX_THINKING_TOKENS,
+    VALID_EFFORT_LEVELS,
     _resolve_effort_level,
 )
 
@@ -1581,6 +1582,18 @@ class TestThinkingSettings:
             result = _resolve_effort_level()
         assert result == DEFAULT_EFFORT_LEVEL
         assert "Invalid ASKCC_CLAUDE_EFFORT_LEVEL" in caplog.text
+
+    def test_xhigh_effort_level_resolves_without_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("ASKCC_CLAUDE_EFFORT_LEVEL", "xhigh")
+        with caplog.at_level("WARNING", logger="askcc.settings"):
+            result = _resolve_effort_level()
+        assert result == VALID_EFFORT_LEVELS.XHIGH
+        assert "Invalid ASKCC_CLAUDE_EFFORT_LEVEL" not in caplog.text
+
+    def test_default_effort_level_is_xhigh(self):
+        assert DEFAULT_EFFORT_LEVEL == VALID_EFFORT_LEVELS.XHIGH
 
     def test_max_thinking_tokens_from_env(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("ASKCC_CLAUDE_MAX_THINKING_TOKENS", "50000")

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Adds `XHIGH = "xhigh"` to `VALID_EFFORT_LEVELS` between `HIGH` and `MAX` (Opus 4.7-only effort tier from Anthropic's [effort docs](https://platform.claude.com/docs/en/build-with-claude/effort)).
- Changes `DEFAULT_EFFORT_LEVEL` from `MAX` to `XHIGH` to match Anthropic's recommended starting point for coding/agentic work on Opus 4.7.
- Bumps version to `0.2.5` (pyproject.toml + uv.lock).

Refs #81

## Notes
- `askcc/cli.py` uses `choices=VALID_EFFORT_LEVELS` and the help string renders `settings.ASKCC_CLAUDE_EFFORT_LEVEL` dynamically, so `--effort xhigh` and the new default surface automatically.
- `_resolve_effort_level()` iterates the enum for its warning message — no code change there, but I confirmed `ASKCC_CLAUDE_EFFORT_LEVEL=xhigh` no longer triggers the invalid-value warning.
- README does not reference effort levels, so no doc updates needed there.

## Test plan
- [x] `uv run poe check` (ruff) — passes
- [x] `uv run poe typecheck` (pyright) — 0 errors
- [x] `uv run poe test` — 155 passed (incl. 2 new tests: `test_xhigh_effort_level_resolves_without_warning`, `test_default_effort_level_is_xhigh`)
- [x] Existing tests for `low`/`high`/`max`/invalid values still pass unchanged