### PR TITLE
:bug: Fix _has_acceptance_criteria false-negative on ### sub-headings (closes #83)

### DIFF
--- a/askcc/functions.py
+++ b/askcc/functions.py
@@ -299,12 +299,17 @@ def _run_project_verification(cwd: Path) -> VerificationResult:
 
 
 def _has_acceptance_criteria(body: str) -> bool:
-    """Check for an acceptance criteria section with checklist items."""
-    match = re.search(r"#{2,}\s+acceptance\s+criteria", body, re.IGNORECASE)
+    """Check for an acceptance criteria section with checklist items.
+
+    The section ends at the next heading at the same level or higher (fewer #s),
+    so deeper sub-headings (e.g. ### inside an ## section) stay part of it.
+    """
+    match = re.search(r"(#{2,})\s+acceptance\s+criteria", body, re.IGNORECASE)
     if not match:
         return False
+    heading_level = len(match.group(1))
     section_start = match.end()
-    next_heading = re.search(r"\n#{2,}\s+", body[section_start:])
+    next_heading = re.search(rf"\n#{{1,{heading_level}}}\s+", body[section_start:])
     section = body[section_start : section_start + next_heading.start()] if next_heading else body[section_start:]
     return bool(re.search(r"-\s*\[[\sx]\]", section))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.6"
+version = "0.2.7"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -610,6 +610,31 @@ class TestHasAcceptanceCriteria:
         body = "### Acceptance Criteria\n- [ ] Works with h3\n"
         assert _has_acceptance_criteria(body) is True
 
+    def test_h2_section_with_h3_subheadings(self):
+        body = (
+            "## Acceptance Criteria\n\n"
+            "### Core Responder Abstraction\n"
+            "- [ ] Responder ABC defined\n"
+            "- [ ] validate_input pass-through\n\n"
+            "### Guardrail\n"
+            "- [ ] LLMGuardrail class defined\n"
+        )
+        assert _has_acceptance_criteria(body) is True
+
+    def test_h2_section_with_h3_subheadings_then_other_h2(self):
+        body = (
+            "## Acceptance Criteria\n\n### Group A\n- [ ] Item one\n\n## Other Section\n- [ ] Should not be counted\n"
+        )
+        assert _has_acceptance_criteria(body) is True
+
+    def test_h3_section_with_h4_subheadings(self):
+        body = "### Acceptance Criteria\n\n#### Subgroup\n- [ ] Item under h4\n"
+        assert _has_acceptance_criteria(body) is True
+
+    def test_h3_section_terminated_by_sibling_h3(self):
+        body = "### Acceptance Criteria\nPlain text with no checklist.\n\n### Other\n- [ ] Wrong section\n"
+        assert _has_acceptance_criteria(body) is False
+
 
 class TestHasDependenciesSection:
     def test_dependencies_heading(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Fixes #83: `_has_acceptance_criteria` returned `False` for valid AC sections that contain `###` sub-headings (a structure encouraged by `PREPARE_SYSTEM_PROMPT.md`).
- The next-heading regex `\n#{2,}\s+` matched any heading at level 2 or deeper, so a `###` sub-heading inside an `## Acceptance Criteria` section truncated the search range before any `- [ ]` items.
- Made the next-heading regex level-aware: detect the AC heading's level (`##`, `###`, ...) and stop only at headings of the same level or higher. The simpler fix proposed in the issue (`r"\n#{1,2}\s+"`) would have broken the existing `### Acceptance Criteria` case where a sibling `### Other` should terminate the section.
- Bumped version 0.2.6 → 0.2.7.

## Test plan

- [x] Added 4 tests to `TestHasAcceptanceCriteria` covering the bug and the level-aware termination behaviour
- [x] Confirmed the new tests fail before the fix and pass after
- [x] `uv run pytest` — 182 passed
- [x] `uv run poe check` — ruff clean
- [x] `uv run poe typecheck` — pyright clean