### PR TITLE
:bug: Add CHANGES_REQUESTED pre-merge guard to pr-review prompt

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -467,6 +467,12 @@ Pre-review:
 - Check out the PR branch using `gh pr checkout <number>` to inspect the full source.
 - Run the project's test suite to confirm all tests pass.
 
+Pre-merge guard (CHANGES_REQUESTED):
+- Before merging, check for unresolved CHANGES_REQUESTED reviews using \
+`gh pr view <number> -R <owner/repo> --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")]'`.
+- If any CHANGES_REQUESTED reviews exist, DO NOT merge. Instead, address the requested changes, \
+reply to all inline comments, push a follow-up fix commit on the PR branch, and re-request review.
+
 Definition of Done checklist:
 1. **Acceptance criteria** — verify each criterion from the issue is satisfied by the code changes.
 2. **Test coverage** — new and changed logic has unit tests. Look for untested code paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.7"
+version = "0.2.8"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -13,6 +13,7 @@ from askcc.cli import main
 from askcc.definitions import (
     AGENT_CONFIGS,
     DEVELOP_AGENT_PROMPT,
+    REVIEWPR_AGENT_PROMPT,
     AgentAction,
     AgentConfig,
     SupportedLanguage,
@@ -276,6 +277,25 @@ class TestDevelopPromptTddContent:
 
     def test_removes_legacy_write_tests_line(self):
         assert "Write tests for every new or changed behavior" not in DEVELOP_AGENT_PROMPT
+
+
+class TestReviewprPromptMergeGuard:
+    """The pr-review prompt must block merging when CHANGES_REQUESTED reviews exist (issue #86)."""
+
+    def test_includes_changes_requested_check_command(self):
+        assert (
+            "gh pr view <number> -R <owner/repo> --json reviews --jq '[.reviews[] "
+            '| select(.state == "CHANGES_REQUESTED")]\'' in REVIEWPR_AGENT_PROMPT
+        )
+
+    def test_includes_do_not_merge_instruction(self):
+        assert "DO NOT merge" in REVIEWPR_AGENT_PROMPT
+
+    def test_includes_address_inline_comments_instruction(self):
+        assert "reply to all inline comments" in REVIEWPR_AGENT_PROMPT
+
+    def test_includes_pre_merge_guard_heading(self):
+        assert "Pre-merge guard" in REVIEWPR_AGENT_PROMPT
 
 
 class TestWritePromptContent:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #86.

The `pr-review` agent has been merging PRs that had unresolved `CHANGES_REQUESTED` reviews (see `weyucou/ellen-core#118`). The agent has `Bash(gh:*,git:*)` access and the prompt never instructed it to check review state before any merge action.

This change adds a `Pre-merge guard (CHANGES_REQUESTED)` block to `REVIEWPR_AGENT_PROMPT` in `askcc/definitions.py` that:
- Requires running `gh pr view <number> -R <owner/repo> --json reviews --jq '[.reviews[] | select(.state == \"CHANGES_REQUESTED\")]'` before merging.
- If any results return, the agent MUST NOT merge; instead address the changes, reply to all inline comments, push a fix commit, and re-request review.

## Key Flows

\`\`\`mermaid
flowchart TD
    A[pr-review starts] --> B[Pre-review: read diff, run tests]
    B --> C[Pre-merge guard: gh pr view --jq CHANGES_REQUESTED]
    C -->|none| D[Definition of Done checklist]
    C -->|any| E[Address changes + reply inline + push fix + re-request review]
    E --> F[Stop, do NOT merge]
    D --> G[Post review via gh pr review]
\`\`\`

## Verification

- \`uv run poe test\` — passed (186 tests)
- \`uv run poe check\` — passed (ruff, no issues)
- \`uv run poe typecheck\` — passed (pyright, 0 errors)

Followed red/green TDD: 4 new tests in \`TestReviewprPromptMergeGuard\` were added first and confirmed failing, then the prompt was updated to make them pass.

## Test plan

- [ ] On a PR with an open CHANGES_REQUESTED review, run \`askcc pr-review -g <issue-url>\` and confirm the agent does NOT merge — instead addresses comments and pushes a fix.
- [ ] On a PR with no CHANGES_REQUESTED reviews, confirm the agent still posts an APPROVE review as before.