### PR TITLE
:bug: Add test plan checklist update to develop prompt (closes #88)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -281,7 +281,19 @@ Skip this section if the change is trivial (e.g. config-only, docs-only, single-
 On completion:
 - Run /simplify or /refactor to simplify and improve the code.
 - Commit, push the feature branch, and open a PR linked to the issue.
+- Update the test plan checklist in the PR description (see "Test plan update" below).
 - Add an issue comment summarizing what was implemented.
+
+Test plan update:
+- After opening the PR, read the PR description with `gh pr view <number> --json body -q .body`.
+- Look for a `## Test plan` section containing checklist items (`- [ ]` checkboxes).
+- For each test plan task, decide whether it is satisfied by the implementation, \
+the new tests you wrote, or the verification gate run (pytest/ruff/pyright).
+- Check off satisfied tasks by replacing `- [ ]` with `- [x]` in the PR body.
+- Leave items requiring manual/external verification (browser QA, deployment \
+validation, etc.) unchecked.
+- Update the PR description with `gh pr edit <number> --body "<updated body>"`.
+- If no `## Test plan` section exists, skip this step silently.
 """
 
 REVIEW_AGENT_PROMPT = (

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -279,6 +279,34 @@ class TestDevelopPromptTddContent:
         assert "Write tests for every new or changed behavior" not in DEVELOP_AGENT_PROMPT
 
 
+class TestDevelopPromptTestPlanUpdate:
+    """The develop prompt must update the PR test plan after PR creation (issue #88).
+
+    Assertions are literal-substring matches: prompt-wording changes will surface
+    here intentionally. Don't "fix" them away — update both the prompt and the
+    asserted substrings together, mirroring the TestReviewprPromptMergeGuard precedent.
+    """
+
+    def test_includes_test_plan_update_section_heading(self):
+        assert "Test plan update:" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_pr_body_read_command(self):
+        assert "gh pr view <number> --json body -q .body" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_pr_body_edit_command(self):
+        assert 'gh pr edit <number> --body "<updated body>"' in DEVELOP_AGENT_PROMPT
+
+    def test_includes_manual_verification_carveout(self):
+        assert "manual/external verification" in DEVELOP_AGENT_PROMPT
+        assert "unchecked" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_noop_when_no_test_plan_section(self):
+        assert "If no `## Test plan` section exists, skip this step" in DEVELOP_AGENT_PROMPT
+
+    def test_completion_step_references_test_plan_update(self):
+        assert "Update the test plan checklist in the PR description" in DEVELOP_AGENT_PROMPT
+
+
 class TestReviewprPromptMergeGuard:
     """The pr-review prompt must block merging when CHANGES_REQUESTED reviews exist (issue #86)."""
 


### PR DESCRIPTION
## Summary

- Insert a "Update the test plan checklist in the PR description" bullet into `DEVELOP_AGENT_PROMPT`'s "On completion" block (between PR push and issue comment).
- Append a "Test plan update:" section mirroring the read → mark → edit flow already in `REVIEWPR_AGENT_PROMPT`, with explicit carveouts for manual/external verification items and a silent no-op when no `## Test plan` section exists.
- Add `TestDevelopPromptTestPlanUpdate` to `tests/test_askcc.py` (between `TestDevelopPromptTddContent` and `TestReviewprPromptMergeGuard`) with literal-substring assertions on the new wording, mirroring the `TestReviewprPromptMergeGuard` precedent.

## Key Flows

```mermaid
flowchart TD
    A[develop completes] --> B[run /simplify or /refactor]
    B --> C[commit & push branch]
    C --> D[open PR linked to issue]
    D --> E{Test plan section present?}
    E -- no --> G[skip silently]
    E -- yes --> F[mark satisfied items - x , leave manual items - blank]
    F --> H[gh pr edit --body updated]
    G --> I[add issue comment summary]
    H --> I
```

## Verification

- `uv run pytest` — passed (192 tests)
- `uv run ruff check` — passed (no issues)
- `uv run pyright` — passed (0 errors, 0 warnings)

## Test plan

- [x] `DEVELOP_AGENT_PROMPT` instructs the agent to update test plan items in the PR description after PR creation
- [x] Instruction explicitly says to leave items requiring manual/external verification unchecked
- [x] Instruction is a no-op when no `## Test plan` section exists
- [x] Unit tests assert the new instruction strings are present in `DEVELOP_AGENT_PROMPT`
- [x] `uv run pytest`, `uv run ruff check`, and `uv run pyright` all pass