### PR TITLE
:bug: Forbid linter/type-checker config relaxation in develop and fix-ci prompts (closes #89)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -178,6 +178,29 @@ Use `gh issue comment <url> --body "<your summary>"`.
 """
 )
 
+# Shared constraint reused by DEVELOP_AGENT_PROMPT and FIXCI_AGENT_PROMPT to keep
+# wording in sync between the two prompts (issue #89).
+CONFIG_BOUNDARIES_BODY = """\
+- Do NOT modify linter, formatter, or type-checker config files \
+(pyproject.toml [tool.ruff]/[tool.pyright]/[tool.mypy] sections, .ruff.toml, \
+pyrightconfig.json, mypy.ini, .pre-commit-config.yaml, ESLint/Prettier configs) \
+to silence errors. Fix the code, not the config.
+- Do NOT add `# noqa`, `# type: ignore`, `# pyright: ignore`, `eslint-disable`, \
+or similar inline suppression comments. Fix the underlying issue.
+- The only exceptions are when the originating issue explicitly requests a \
+configuration or rule change, or when a known third-party bug requires \
+documented suppression — in which case add a comment explaining why."""
+
+DEVELOP_CONFIG_BOUNDARIES = (
+    "Configuration boundaries (do not cross unless the issue explicitly requests it):\n" + CONFIG_BOUNDARIES_BODY
+)
+
+FIXCI_CONFIG_BOUNDARIES = (
+    "## Configuration boundaries\n\n"
+    "Do not cross these boundaries unless the issue explicitly requests it:\n\n" + CONFIG_BOUNDARIES_BODY
+)
+
+
 # NOTE: develop and fix-ci require write access (Edit/Write/Bash) to actually
 # implement changes and run tests. The runner currently passes
 # `--dangerously-skip-permissions` globally so all actions run unattended; the
@@ -258,6 +281,8 @@ Security checklist (verify before committing):
 - No unsafe input handling — validate and sanitize all external input at system boundaries.
 - No hardcoded credentials or connection strings — use environment variables or secrets management.
 - No overly permissive file or network access introduced by the change.
+
+{DEVELOP_CONFIG_BOUNDARIES}
 
 PR description:
 - Include a `## Key Flows` section with mermaid diagrams illustrating the main flows \
@@ -539,7 +564,8 @@ DEVELOP_USER_PROMPT_TEMPLATE = (
 # See note above DEVELOP_AGENT_PROMPT — fix-ci is a write-capable action that
 # needs Edit/Write/Bash to apply CI fixes; rely on the tools allowlist below for
 # the per-action safety boundary.
-FIXCI_AGENT_PROMPT = """\
+FIXCI_AGENT_PROMPT = (
+    """\
 ---
 name: fix-ci
 description: Identifies failing CI checks on the current PR or branch and implements fixes
@@ -573,6 +599,10 @@ Goal: Identify failing CI checks on the current PR or branch and implement fixes
    - **Build errors**: import errors, syntax errors, missing dependencies
    - **Type errors**: pyright/mypy errors — fix type annotations
 
+"""
+    + FIXCI_CONFIG_BOUNDARIES
+    + """
+
 ## Fixing Failures
 
 7. Read all relevant source files before making changes. Do not speculate about code you have not opened.
@@ -594,6 +624,7 @@ Goal: Identify failing CI checks on the current PR or branch and implement fixes
 
 IMPORTANT: Only fix CI failures. Do not introduce new features or unrelated changes.
 """
+)
 
 FIXCI_USER_PROMPT_TEMPLATE = (
     "Identify failing CI checks on the current branch or linked PR and implement fixes to make them pass."

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -13,6 +13,7 @@ from askcc.cli import main
 from askcc.definitions import (
     AGENT_CONFIGS,
     DEVELOP_AGENT_PROMPT,
+    FIXCI_AGENT_PROMPT,
     REVIEWPR_AGENT_PROMPT,
     AgentAction,
     AgentConfig,
@@ -296,6 +297,67 @@ class TestReviewprPromptMergeGuard:
 
     def test_includes_pre_merge_guard_heading(self):
         assert "Pre-merge guard" in REVIEWPR_AGENT_PROMPT
+
+
+class TestConfigBoundaryConstraints:
+    """Both develop and fix-ci prompts must forbid relaxing linter/type-checker config (issue #89)."""
+
+    def test_develop_prompt_includes_config_boundaries_heading(self):
+        assert "Configuration boundaries" in DEVELOP_AGENT_PROMPT
+
+    def test_develop_prompt_forbids_modifying_linter_config(self):
+        assert "pyproject.toml" in DEVELOP_AGENT_PROMPT
+        assert "[tool.ruff]" in DEVELOP_AGENT_PROMPT
+        assert "[tool.pyright]" in DEVELOP_AGENT_PROMPT
+        assert "[tool.mypy]" in DEVELOP_AGENT_PROMPT
+        assert ".ruff.toml" in DEVELOP_AGENT_PROMPT
+        assert "pyrightconfig.json" in DEVELOP_AGENT_PROMPT
+        assert "mypy.ini" in DEVELOP_AGENT_PROMPT
+        assert ".pre-commit-config.yaml" in DEVELOP_AGENT_PROMPT
+        assert "ESLint/Prettier" in DEVELOP_AGENT_PROMPT
+        assert "Fix the code, not the config." in DEVELOP_AGENT_PROMPT
+
+    def test_develop_prompt_forbids_inline_suppression_comments(self):
+        assert "# noqa" in DEVELOP_AGENT_PROMPT
+        assert "# type: ignore" in DEVELOP_AGENT_PROMPT
+        assert "# pyright: ignore" in DEVELOP_AGENT_PROMPT
+        assert "eslint-disable" in DEVELOP_AGENT_PROMPT
+
+    def test_develop_prompt_documents_exceptions(self):
+        assert "issue explicitly requests" in DEVELOP_AGENT_PROMPT
+        assert "third-party bug" in DEVELOP_AGENT_PROMPT
+
+    def test_fixci_prompt_includes_config_boundaries_heading(self):
+        assert "Configuration boundaries" in FIXCI_AGENT_PROMPT
+
+    def test_fixci_prompt_places_boundaries_before_fixing_failures(self):
+        boundaries_idx = FIXCI_AGENT_PROMPT.find("Configuration boundaries")
+        fixing_idx = FIXCI_AGENT_PROMPT.find("## Fixing Failures")
+        assert boundaries_idx != -1
+        assert fixing_idx != -1
+        assert boundaries_idx < fixing_idx
+
+    def test_fixci_prompt_forbids_modifying_linter_config(self):
+        assert "pyproject.toml" in FIXCI_AGENT_PROMPT
+        assert "[tool.ruff]" in FIXCI_AGENT_PROMPT
+        assert "[tool.pyright]" in FIXCI_AGENT_PROMPT
+        assert "[tool.mypy]" in FIXCI_AGENT_PROMPT
+        assert ".ruff.toml" in FIXCI_AGENT_PROMPT
+        assert "pyrightconfig.json" in FIXCI_AGENT_PROMPT
+        assert "mypy.ini" in FIXCI_AGENT_PROMPT
+        assert ".pre-commit-config.yaml" in FIXCI_AGENT_PROMPT
+        assert "ESLint/Prettier" in FIXCI_AGENT_PROMPT
+        assert "Fix the code, not the config." in FIXCI_AGENT_PROMPT
+
+    def test_fixci_prompt_forbids_inline_suppression_comments(self):
+        assert "# noqa" in FIXCI_AGENT_PROMPT
+        assert "# type: ignore" in FIXCI_AGENT_PROMPT
+        assert "# pyright: ignore" in FIXCI_AGENT_PROMPT
+        assert "eslint-disable" in FIXCI_AGENT_PROMPT
+
+    def test_fixci_prompt_documents_exceptions(self):
+        assert "issue explicitly requests" in FIXCI_AGENT_PROMPT
+        assert "third-party bug" in FIXCI_AGENT_PROMPT
 
 
 class TestWritePromptContent:


### PR DESCRIPTION
## Summary

Closes #89.

- Add a `Configuration boundaries` section to both `DEVELOP_AGENT_PROMPT` and `FIXCI_AGENT_PROMPT` (`askcc/definitions.py`) that explicitly forbids modifying linter/formatter/type-checker config files (`pyproject.toml [tool.ruff]/[tool.pyright]/[tool.mypy]`, `.ruff.toml`, `pyrightconfig.json`, `mypy.ini`, `.pre-commit-config.yaml`, ESLint/Prettier configs) or adding inline suppression comments (`# noqa`, `# type: ignore`, `# pyright: ignore`, `eslint-disable`) to silence errors.
- Document the narrow exceptions: when the originating issue explicitly requests a configuration/rule change, or a known third-party bug requires documented suppression with an explanatory comment.
- Share the wording via a module-level `CONFIG_BOUNDARIES_BODY` constant (composed into `DEVELOP_CONFIG_BOUNDARIES` with the prose-style heading used by `DEVELOP_AGENT_PROMPT`, and into `FIXCI_CONFIG_BOUNDARIES` with the `## Section` heading used by `FIXCI_AGENT_PROMPT`) so the two prompts cannot drift.
- Add `TestConfigBoundaryConstraints` (9 tests) in `tests/test_askcc.py` asserting that both prompts contain the heading, the listed config files, the forbidden suppression comments, and the documented exceptions — plus a placement check that `Configuration boundaries` precedes `## Fixing Failures` in the fix-ci prompt.

No runtime/API/schema changes — only the prompt strings sent to downstream Claude agents are modified.

## Verification

- `uv run pytest` — passed (195 tests, including the 9 new `TestConfigBoundaryConstraints` tests)
- `uv run ruff check` — passed (no issues)
- `uv run pyright` — passed (0 errors, 0 warnings)

## Test plan

- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run pyright` passes
- [x] New `TestConfigBoundaryConstraints` test class covers develop + fix-ci prompts