### PR TITLE
:bug: Add verify-before-asserting-existence rule to plan prompt

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -123,8 +123,16 @@ Goal: Analyze the GitHub issue against this codebase and produce a structured im
 
 Read relevant source files, tests, and config before planning. Do not speculate about unopened code.
 
+Verify before asserting existence: for every symbol you propose to add (model field, function, \
+class, setting, file), first `grep -n '<name>' <target_file>` or Read the target file to confirm \
+absence. Never write "<symbol> does not currently exist" or propose `AddField` / "create new \
+<file>" steps based on issue text alone. If grep finds the symbol, the step becomes "modify \
+existing", and any migration must NOT include `AddField` for an already-present column.
+
 Your plan must include:
-1. Current state — what exists today related to the issue.
+1. Current state — what exists today related to the issue. Cite `file:line` for each existing \
+symbol referenced; for any symbol you claim is missing, cite the negative grep result \
+(e.g. `grep -n 'foo' models.py → no match`).
 2. Step-by-step implementation tasks, each referencing specific files and functions.
 3. Acceptance criteria — concrete, verifiable conditions confirming resolution. \
 Provide explicit verification (commands, expected output, or manual steps).

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -123,11 +123,9 @@ Goal: Analyze the GitHub issue against this codebase and produce a structured im
 
 Read relevant source files, tests, and config before planning. Do not speculate about unopened code.
 
-Verify before asserting existence: for every symbol you propose to add (model field, function, \
-class, setting, file), first `grep -n '<name>' <target_file>` or Read the target file to confirm \
-absence. Never write "<symbol> does not currently exist" or propose `AddField` / "create new \
-<file>" steps based on issue text alone. If grep finds the symbol, the step becomes "modify \
-existing", and any migration must NOT include `AddField` for an already-present column.
+For any change proposal, assert that the change does not already exist. Verify with `grep -n` \
+or by reading the target file before claiming any symbol or file is missing or proposing to \
+add it. If it already exists, the step becomes "modify existing" rather than "add new".
 
 Your plan must include:
 1. Current state — what exists today related to the issue. Cite `file:line` for each existing \


### PR DESCRIPTION
## Summary

Tightens `PLAN_AGENT_PROMPT` to prevent the plan agent from claiming a symbol does not exist when it actually does — the failure mode reported in #95.

## Why

The current prompt's *"Do not speculate about unopened code"* guidance is too soft. In a recent run on kiconiaworks/kippo#7 the agent emitted an `AddField` step for `display_in_project_report`, even though the field is already defined at `kippo/projects/models.py:206`. If implemented as written, the migration would fail at apply time (`column ... already exists`) and the duplicate Python attribute could silently overwrite `verbose_name`/`help_text`.

## Changes

`askcc/definitions.py` — `PLAN_AGENT_PROMPT`:

- New paragraph: *"Verify before asserting existence"* — for every symbol the plan proposes to add (field, function, class, setting, file), require a `grep -n` or Read-based confirmation of absence before writing "does not currently exist" or proposing `AddField` / "create new" steps.
- Tightened item 1 (Current state): require `file:line` citation for existing symbols and a negative-grep citation for any "missing" claim.

## Verification

- `uv run pytest` — 225 passed
- `uv run poe check` (ruff) — clean
- `uv run poe typecheck` (pyright) — 0 errors

## Test plan

- [ ] Re-run `askcc plan` against an issue mentioning an existing model field; confirm the plan does not include an `AddField` step for that field.
- [ ] Confirm the "Current state" section of generated plans cites `file:line` for referenced symbols.

Closes #95