### PR TITLE
:bug: Require AC + Dependencies headings in plan prompt (closes #96)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -152,16 +152,25 @@ Analyze description and comment history to understand what's been discussed, dec
 (e.g., answers to prepare-step questions).
 
 Rewrite the issue body to be development-ready: `gh issue edit <url> --body "<updated body>"`. \
-The body should define what needs to be built, incorporating decisions from comments. Include:
+The body MUST contain all of the following sections — add any that are missing:
 
-1. **Acceptance Criteria** — replace any existing `## Acceptance Criteria` section \
-(including `<!-- draft -->` variants) with a finalized `## Acceptance Criteria` `- [ ]` checklist \
-derived from your plan.
-2. **Dependencies** — replace any existing `## Dependencies` section (including `<!-- draft -->` \
-variants) with a finalized list. If none, include the heading with "None identified."
+1. **Acceptance Criteria** — the body MUST contain a `## Acceptance Criteria` heading with at \
+least one `- [ ]` checklist item derived from your plan. If a section exists (including \
+`<!-- draft -->` variants), replace it; otherwise add it. Rename non-canonical headings like \
+`## Tasks` or `## Requirements` to `## Acceptance Criteria` rather than leaving them.
+2. **Dependencies** — the body MUST contain a `## Dependencies` heading. Replace any existing \
+one (including `<!-- draft -->` variants); if none exists, add it with "None identified."
 3. **Implementation Plan** — add `## Implementation Plan` with step-by-step tasks referencing \
 specific files and functions.
 4. **Assignee** — assign to the authenticated user: `gh issue edit <url> --add-assignee "@me"`.
+
+## Post-Update Verification
+
+After editing, re-read the body (`gh issue view <url> --json body -q .body`) and confirm it \
+contains both a `## Acceptance Criteria` heading with at least one `- [ ]` checklist item AND a \
+`## Dependencies` (or Prerequisites/Context/Blockers) heading. If either check fails, re-edit \
+the body and re-verify. Do not stop until both are present — `develop` will reject the issue \
+otherwise.
 
 ## Summary Comment
 

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -154,23 +154,23 @@ Analyze description and comment history to understand what's been discussed, dec
 Rewrite the issue body to be development-ready: `gh issue edit <url> --body "<updated body>"`. \
 The body MUST contain all of the following sections — add any that are missing:
 
-1. **Acceptance Criteria** — the body MUST contain a `## Acceptance Criteria` heading with at \
-least one `- [ ]` checklist item derived from your plan. If a section exists (including \
-`<!-- draft -->` variants), replace it; otherwise add it. Rename non-canonical headings like \
-`## Tasks` or `## Requirements` to `## Acceptance Criteria` rather than leaving them.
-2. **Dependencies** — the body MUST contain a `## Dependencies` heading. Replace any existing \
-one (including `<!-- draft -->` variants); if none exists, add it with "None identified."
-3. **Implementation Plan** — add `## Implementation Plan` with step-by-step tasks referencing \
+1. **Acceptance Criteria** — `## Acceptance Criteria` heading with at least one `- [ ]` \
+checklist item derived from your plan. Replace any existing section (including `<!-- draft -->` \
+variants); rename non-canonical headings like `## Tasks` or `## Requirements`.
+2. **Dependencies** — `## Dependencies` heading. Replace any existing section (including \
+`<!-- draft -->` variants); if none, use "None identified."
+3. **Implementation Plan** — `## Implementation Plan` with step-by-step tasks referencing \
 specific files and functions.
-4. **Assignee** — assign to the authenticated user: `gh issue edit <url> --add-assignee "@me"`.
+4. **Assignee** — assign the authenticated user: `gh issue edit <url> --add-assignee "@me"`.
+
+Keep prose concise; prefer bullet lists over paragraphs.
 
 ## Post-Update Verification
 
-After editing, re-read the body (`gh issue view <url> --json body -q .body`) and confirm it \
-contains both a `## Acceptance Criteria` heading with at least one `- [ ]` checklist item AND a \
-`## Dependencies` (or Prerequisites/Context/Blockers) heading. If either check fails, re-edit \
-the body and re-verify. Do not stop until both are present — `develop` will reject the issue \
-otherwise.
+Re-read the body (`gh issue view <url> --json body -q .body`) and confirm both \
+`## Acceptance Criteria` (with a `- [ ]` checklist item) and `## Dependencies` (or \
+Prerequisites/Context/Blockers) headings are present. Re-edit and re-verify until both pass — \
+`develop` rejects the issue otherwise.
 
 ## Summary Comment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.9"
+version = "0.2.10"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Closes the contract gap between `askcc plan` and `askcc develop` reported in #96: `plan` could succeed without writing `## Acceptance Criteria` / `## Dependencies` headings, leaving `develop`'s `validate_issue_readiness` to fail immediately.

## Why

`PLAN_AGENT_PROMPT` items 1 and 2 used "replace any existing X" wording, which is ambiguous when no existing X is present. Item 2 explicitly handled the empty case ("If none, include the heading with 'None identified.'"); item 1 did not. A reasonable agent interpretation was *"if no existing section, do nothing,"* leaving the body in a state `develop` rejects.

## Changes

`askcc/definitions.py` — `PLAN_AGENT_PROMPT` issue-description-update section:

- Reworded items 1 and 2 to state the heading **MUST** be present, not just "replaced if found". Item 1 now also instructs renaming non-canonical headings (`## Tasks`, `## Requirements`) to `## Acceptance Criteria`.
- Added a new `## Post-Update Verification` step: after editing, the agent re-reads the body and confirms both required headings are present (with a checklist item under AC), re-editing if either check fails. This converts the contract from *"agent should remember to do it"* to *"agent verifies it before stopping."*

## Verification

- `uv run pytest` — 225 passed
- `uv run poe check` (ruff) — clean
- `uv run poe typecheck` (pyright) — 0 errors

## Test plan

- [ ] Re-run `askcc plan` against a fresh issue with no `## Acceptance Criteria` / `## Dependencies` sections; confirm the resulting body passes `validate_issue_readiness`.
- [ ] Re-run `askcc plan` against an issue with a `## Tasks` heading; confirm the agent renames it to `## Acceptance Criteria` rather than leaving it.
- [ ] Re-run `askcc plan` against an issue that already has `<!-- draft -->` AC / Dependencies sections; confirm replacement still works.