### PR TITLE
fix(prompts): add PR already-reviewed guard and reduce redundant issue comments

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -330,7 +330,9 @@ On completion:
 - If no PR exists, open one linked to the issue.
 - If a PR exists (follow-up changes), review and update its description (see "PR description update") before commenting.
 - Update the test plan checklist (see "Test plan update").
-- Comment on the issue summarizing what was implemented.
+- If this session opened a new PR: comment on the issue summarizing what was implemented.
+- If a PR already existed before this session (follow-up commits): skip the issue comment \
+— the PR description update is sufficient.
 
 {DEVELOP_PR_DESCRIPTION_UPDATE}
 
@@ -522,6 +524,14 @@ Pre-review:
 - Check out the PR branch: `gh pr checkout <number>`.
 - Run the test suite to confirm all tests pass.
 
+Pre-review dedup (skip if already reviewed since last push):
+- `gh pr view <number> -R <owner/repo> --json reviews,commits \
+--jq '{last_commit: (.commits | sort_by(.committedDate) | last | .committedDate), \
+last_review: ([.reviews[] | select(.author.login == "ellen-goc" and (.body|length > 50)) \
+| .submittedAt] | sort | last // "")}'`
+- If `last_review` is non-empty AND `last_review >= last_commit` → skip entirely \
+(no review, no linked-issue comment). Stop immediately.
+
 Pre-merge guard (CHANGES_REQUESTED):
 - Before merging, check for unresolved CHANGES_REQUESTED reviews: \
 `gh pr view <number> -R <owner/repo> --json reviews --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")]'`.
@@ -546,7 +556,6 @@ Your review must include:
 Posting the review:
 - All pass: `gh pr review <number> -R <owner/repo> --approve --body "<review>"`
 - Any fail: `gh pr review <number> -R <owner/repo> --request-changes --body "<review>"`
-- Also post a brief summary on the linked issue: `gh issue comment`.
 
 Update test plan in PR description:
 - Read PR body: `gh pr view <number> -R <owner/repo> --json body -q .body`.

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -332,7 +332,7 @@ On completion:
 - Run /simplify or /refactor to improve the code.
 - Commit and push the feature branch.
 - If no PR exists, open one linked to the issue.
-- If a PR exists (follow-up changes), review and update its description (see "PR description update") before commenting.
+- If a PR exists (follow-up changes), review and update its description (see "PR description update").
 - Update the test plan checklist (see "Test plan update").
 - If this session opened a new PR: comment on the issue summarizing what was implemented.
 - If a PR already existed before this session (follow-up commits): skip the issue comment \

--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -321,6 +321,10 @@ Example:
       C -- any fail --> E[stay in develop]
   `` `
   ```
+- Mermaid label safety: quote labels containing `/`, `\\`, `(`, `)`, `|`, `:`, or starting \
+with punctuation — e.g. `B["/simplify, commit, push"]`, not `B[/simplify, commit, push]`. \
+Unquoted leading `/` or `\\` is parsed as parallelogram/trapezoid shape syntax and breaks \
+rendering with a "Lexical error / Unrecognized text" message.
 - Keep diagrams concise — one or two covering the most important flows. \
 Skip this section for trivial changes (config-only, docs-only, single-line fix).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.10"
+version = "0.2.11"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -442,6 +442,23 @@ class TestDevelopPromptConditionalIssueComment:
         assert "PR description update is sufficient" in DEVELOP_AGENT_PROMPT
 
 
+class TestDevelopPromptMermaidLabelSafety:
+    r"""The develop prompt must instruct quoting mermaid labels with shape-reserved chars.
+
+    Without quoting, labels starting with `/` or `\` are parsed as parallelogram/trapezoid
+    shape syntax (e.g. `B[/simplify]`) and break rendering with a lexical error.
+    """
+
+    def test_includes_label_safety_guidance(self):
+        assert "Mermaid label safety" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_quoted_example(self):
+        assert 'B["/simplify, commit, push"]' in DEVELOP_AGENT_PROMPT
+
+    def test_warns_against_parallelogram_collision(self):
+        assert "parallelogram/trapezoid shape syntax" in DEVELOP_AGENT_PROMPT
+
+
 class TestConfigBoundaryConstraints:
     """Both develop and fix-ci prompts must forbid relaxing linter/type-checker config (issue #89)."""
 

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -393,6 +393,55 @@ class TestReviewprPromptMergeGuard:
         assert "Pre-merge guard" in REVIEWPR_AGENT_PROMPT
 
 
+class TestReviewprPromptDedupGuard:
+    """The pr-review prompt must skip duplicate reviews when no new commits since last review (issue #100).
+
+    Assertions are literal-substring matches: prompt-wording changes will surface
+    here intentionally — update both the prompt and the asserted substrings together,
+    mirroring the TestReviewprPromptMergeGuard precedent.
+    """
+
+    def test_includes_pre_review_dedup_heading(self):
+        assert "Pre-review dedup" in REVIEWPR_AGENT_PROMPT
+
+    def test_includes_dedup_check_command(self):
+        assert "sort_by(.committedDate)" in REVIEWPR_AGENT_PROMPT
+        assert '.author.login == "ellen-goc"' in REVIEWPR_AGENT_PROMPT
+        assert "(.body|length > 50)" in REVIEWPR_AGENT_PROMPT
+        assert "--json reviews,commits" in REVIEWPR_AGENT_PROMPT
+
+    def test_includes_skip_instruction(self):
+        assert "skip entirely" in REVIEWPR_AGENT_PROMPT
+
+    def test_dedup_guard_placed_before_pre_merge_guard(self):
+        assert REVIEWPR_AGENT_PROMPT.index("Pre-review dedup") < REVIEWPR_AGENT_PROMPT.index("Pre-merge guard")
+
+
+class TestReviewprPromptNoLinkedIssueComment:
+    """The pr-review prompt must not unconditionally post a linked-issue comment (issue #100)."""
+
+    def test_does_not_post_linked_issue_comment(self):
+        assert "Also post a brief summary on the linked issue" not in REVIEWPR_AGENT_PROMPT
+
+
+class TestDevelopPromptConditionalIssueComment:
+    """The develop prompt must only comment on the issue when opening a new PR (issue #100).
+
+    Assertions are literal-substring matches: prompt-wording changes will surface
+    here intentionally — update both the prompt and the asserted substrings together.
+    """
+
+    def test_does_not_unconditionally_comment_on_issue(self):
+        assert "- Comment on the issue summarizing what was implemented." not in DEVELOP_AGENT_PROMPT
+
+    def test_includes_new_pr_branch(self):
+        assert "If this session opened a new PR" in DEVELOP_AGENT_PROMPT
+
+    def test_includes_existing_pr_skip_branch(self):
+        assert "PR already existed" in DEVELOP_AGENT_PROMPT
+        assert "PR description update is sufficient" in DEVELOP_AGENT_PROMPT
+
+
 class TestConfigBoundaryConstraints:
     """Both develop and fix-ci prompts must forbid relaxing linter/type-checker config (issue #89)."""
 

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -394,12 +394,7 @@ class TestReviewprPromptMergeGuard:
 
 
 class TestReviewprPromptDedupGuard:
-    """The pr-review prompt must skip duplicate reviews when no new commits since last review (issue #100).
-
-    Assertions are literal-substring matches: prompt-wording changes will surface
-    here intentionally — update both the prompt and the asserted substrings together,
-    mirroring the TestReviewprPromptMergeGuard precedent.
-    """
+    """The pr-review prompt must skip duplicate reviews when no new commits since last review (issue #100)."""
 
     def test_includes_pre_review_dedup_heading(self):
         assert "Pre-review dedup" in REVIEWPR_AGENT_PROMPT
@@ -425,11 +420,7 @@ class TestReviewprPromptNoLinkedIssueComment:
 
 
 class TestDevelopPromptConditionalIssueComment:
-    """The develop prompt must only comment on the issue when opening a new PR (issue #100).
-
-    Assertions are literal-substring matches: prompt-wording changes will surface
-    here intentionally — update both the prompt and the asserted substrings together.
-    """
+    """The develop prompt must only comment on the issue when opening a new PR (issue #100)."""
 
     def test_does_not_unconditionally_comment_on_issue(self):
         assert "- Comment on the issue summarizing what was implemented." not in DEVELOP_AGENT_PROMPT

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Closes #100

## Summary
- Adds a `Pre-review dedup` block to `REVIEWPR_AGENT_PROMPT` (placed before `Pre-merge guard`) that short-circuits when ellen-goc's last substantial review postdates the PR's most recent commit — no review, no linked-issue comment.
- Removes the unconditional `Also post a brief summary on the linked issue` line from `REVIEWPR_AGENT_PROMPT`. The PR review is now the canonical record.
- Replaces the unconditional `Comment on the issue summarizing what was implemented` bullet in `DEVELOP_AGENT_PROMPT` with a two-branch instruction: comment when the session opened a new PR; skip on follow-up commits (the PR description update is sufficient).
- Adds `Mermaid label safety` guidance to `DEVELOP_AGENT_PROMPT` so labels containing `/`, `\`, `(`, `)`, `|`, `:`, etc. get quoted (`B["/simplify, commit, push"]`) instead of being parsed as parallelogram/trapezoid shape syntax — prevents the "Lexical error / Unrecognized text" rendering failure that broke the original PR description.
- Adds `TestReviewprPromptDedupGuard`, `TestReviewprPromptNoLinkedIssueComment`, `TestDevelopPromptConditionalIssueComment`, and `TestDevelopPromptMermaidLabelSafety` to `tests/test_askcc.py` using the existing literal-substring assertion style.

## Verification
- `uv run pytest` — passed (236 tests, +11 new)
- `uv run ruff check` — passed (no issues)
- `uv run pyright` — passed (0 errors, 0 warnings)

## Key Flows

```mermaid
flowchart TD
    A[pr-review triggered] --> B[Pre-review: read diff, gh pr checkout, run tests]
    B --> C{Pre-review dedup:<br/>last_review &gt;= last_commit?}
    C -- yes --> D[Skip entirely:<br/>no review, no issue comment]
    C -- no --> E[Pre-merge guard:<br/>CHANGES_REQUESTED check]
    E --> F[Definition of Done checklist]
    F --> G[gh pr review --approve / --request-changes]
```

```mermaid
flowchart TD
    A[develop completes] --> B["/simplify, commit, push"]
    B --> C{New PR opened<br/>this session?}
    C -- yes --> D[Open PR + comment on issue:<br/>summary of what was implemented]
    C -- no --> E[Update existing PR description:<br/>skip issue comment]
```

## Test plan
- [x] `TestReviewprPromptDedupGuard` asserts `Pre-review dedup` heading, `gh pr view --json reviews,commits` query fragments (`sort_by(.committedDate)`, `.author.login == "ellen-goc"`, `(.body|length > 50)`, `--json reviews,commits`), `skip entirely`, and dedup-before-merge-guard ordering.
- [x] `TestReviewprPromptNoLinkedIssueComment` asserts the removed line is absent.
- [x] `TestDevelopPromptConditionalIssueComment` asserts the unconditional bullet is gone and both conditional branches (`If this session opened a new PR`, `PR already existed`, `PR description update is sufficient`) are present.
- [x] `TestDevelopPromptMermaidLabelSafety` asserts the `Mermaid label safety` heading, the quoted `B["/simplify, commit, push"]` example, and the `parallelogram/trapezoid shape syntax` warning.
- [x] `uv run pytest` / `uv run ruff check` / `uv run pyright` all green locally.
- [ ] Runtime effect verified by observing weyucou/sops PRs on the next review cycle after merge (matches the precedent set by issues #86 / #88 / #89, which also relied on prompt-content tests + post-merge observation).
