### PR TITLE
:bug: Verify assignee in plan post-update verification (closes #106)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -167,10 +167,10 @@ Keep prose concise; prefer bullet lists over paragraphs.
 
 ## Post-Update Verification
 
-Re-read the body (`gh issue view <url> --json body -q .body`) and confirm both \
-`## Acceptance Criteria` (with a `- [ ]` checklist item) and `## Dependencies` (or \
-Prerequisites/Context/Blockers) headings are present. Re-edit and re-verify until both pass — \
-`develop` rejects the issue otherwise.
+Re-read the body and assignees (`gh issue view <url> --json body,assignees`) and confirm \
+(a) `## Acceptance Criteria` heading with a `- [ ]` checklist item, (b) `## Dependencies` (or \
+Prerequisites/Context/Blockers) heading is present, and (c) at least one assignee is set. \
+Re-edit / re-assign and re-verify until all three pass — `develop` rejects the issue otherwise.
 
 ## Summary Comment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.12"
+version = "0.2.13"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Closes the contract gap between `askcc plan` and `askcc develop` for the assignee check, mirroring the AC/Dependencies fix from #96.

## Why

`PLAN_AGENT_PROMPT`'s Post-Update Verification block at `askcc/definitions.py:170-173` re-read the body and confirmed `## Acceptance Criteria` + `## Dependencies` were present, but did **not** verify the assignee. The plan prompt instructs `gh issue edit <url> --add-assignee "@me"` (`definitions.py:164`); a missed assignee step produced a silent failure mode where `develop`'s `validate_issue_readiness` (`functions.py:362-371`) rejected the issue.

This is the same class of contract gap as #96, just for the assignee rather than the body headings.

## Changes

`askcc/definitions.py` — `PLAN_AGENT_PROMPT` Post-Update Verification block:

- Switched the verification fetch from `gh issue view --json body -q .body` to `gh issue view --json body,assignees` (single call, both fields).
- Added "(c) at least one assignee is set" to the verification checks.
- Updated the loop wording from "Re-edit and re-verify until both pass" to "Re-edit / re-assign and re-verify until all three pass" to make the re-assignment path explicit.

`pyproject.toml` / `uv.lock` — version bump 0.2.12 → 0.2.13.

## Verification

- `uv run poe check` (ruff) — clean
- `uv run poe typecheck` (pyright) — 0 errors
- `uv run pytest` — 256 passed

## Test plan

- [ ] Re-run `askcc plan` against a fresh, unassigned issue with no `## Acceptance Criteria` / `## Dependencies` sections; confirm the resulting body passes `validate_issue_readiness` AND the issue has an assignee.
- [ ] Re-run `askcc plan` against an issue that is already assigned and already has the required headings; confirm the verification loop is a no-op.
- [ ] Run `askcc develop` against the issue produced by the first test; confirm pre-flight passes 4/4 checks.