### PR TITLE
:memo: Rename /simplify references to /code-review (bump 0.2.14)

### DIFF
--- a/askcc/definitions.py
+++ b/askcc/definitions.py
@@ -322,14 +322,14 @@ Example:
   `` `
   ```
 - Mermaid label safety: quote labels containing `/`, `\\`, `(`, `)`, `|`, `:`, or starting \
-with punctuation — e.g. `B["/simplify, commit, push"]`, not `B[/simplify, commit, push]`. \
+with punctuation — e.g. `B["/code-review, commit, push"]`, not `B[/code-review, commit, push]`. \
 Unquoted leading `/` or `\\` is parsed as parallelogram/trapezoid shape syntax and breaks \
 rendering with a "Lexical error / Unrecognized text" message.
 - Keep diagrams concise — one or two covering the most important flows. \
 Skip this section for trivial changes (config-only, docs-only, single-line fix).
 
 On completion:
-- Run /simplify or /refactor to improve the code.
+- Run /code-review or /refactor to improve the code.
 - Commit and push the feature branch.
 - If no PR exists, open one linked to the issue.
 - If a PR exists (follow-up changes), review and update its description (see "PR description update").

--- a/askcc/skills/handle-github-issue/SKILL.md
+++ b/askcc/skills/handle-github-issue/SKILL.md
@@ -229,10 +229,10 @@ PR description:
 - Include `## Key Flows` with mermaid diagrams for the main flows changed by this PR. Focus on control flow,
   data flow, or state transitions. Skip this section for trivial changes (config-only, docs-only, single-line fix).
 - Mermaid label safety: quote labels containing `/`, `\`, `(`, `)`, `|`, `:`, or starting with punctuation —
-  e.g. `B["/simplify, commit, push"]`, not `B[/simplify, commit, push]`.
+  e.g. `B["/code-review, commit, push"]`, not `B[/code-review, commit, push]`.
 
 On completion:
-- Run /simplify or /refactor to improve the code.
+- Run /code-review or /refactor to improve the code.
 - Commit and push the feature branch.
 - If no PR exists, open one linked to the issue.
 - If a PR exists (follow-up changes), review and update its description (see "PR description update" below).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "askcc"
-version = "0.2.13"
+version = "0.2.14"
 description = "A one-shot cc cli executor"
 authors = [{ name = "mknt", email = "shane.cousins@gmail.com" }]
 readme = "README.md"

--- a/tests/test_askcc.py
+++ b/tests/test_askcc.py
@@ -445,14 +445,14 @@ class TestDevelopPromptMermaidLabelSafety:
     r"""The develop prompt must instruct quoting mermaid labels with shape-reserved chars.
 
     Without quoting, labels starting with `/` or `\` are parsed as parallelogram/trapezoid
-    shape syntax (e.g. `B[/simplify]`) and break rendering with a lexical error.
+    shape syntax (e.g. `B[/code-review]`) and break rendering with a lexical error.
     """
 
     def test_includes_label_safety_guidance(self):
         assert "Mermaid label safety" in DEVELOP_AGENT_PROMPT
 
     def test_includes_quoted_example(self):
-        assert 'B["/simplify, commit, push"]' in DEVELOP_AGENT_PROMPT
+        assert 'B["/code-review, commit, push"]' in DEVELOP_AGENT_PROMPT
 
     def test_warns_against_parallelogram_collision(self):
         assert "parallelogram/trapezoid shape syntax" in DEVELOP_AGENT_PROMPT

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.13"
+version = "0.2.14"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- The `/simplify` slash command was renamed upstream to `/code-review`. Updates all references in prompts, skills, and tests.
- Bumps version `0.2.13` → `0.2.14`.

## Changes
- `askcc/definitions.py` — develop agent prompt: mermaid label-safety example + on-completion guidance now reference `/code-review`.
- `askcc/skills/handle-github-issue/SKILL.md` — same two references updated.
- `tests/test_askcc.py` — `TestDevelopPromptMermaidLabelSafety` assertions updated in lockstep with the prompt string.
- `pyproject.toml` + `uv.lock` — version bump.

## Test plan
- [x] `uv run poe check` passes
- [x] `uv run pytest tests/test_askcc.py` — 42 passed