### PR TITLE
:bookmark: Sync uv.lock to 0.2.15

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "askcc"
-version = "0.2.14"
+version = "0.2.15"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Problem

PR #117 bumped `pyproject.toml` to 0.2.15 but did not update `uv.lock`, which pins the editable root package's own version. `main` is currently inconsistent:

| File | Version on `main` |
|---|---|
| `pyproject.toml` | 0.2.15 |
| `uv.lock` | 0.2.14 |

Nothing is broken by this — `release.yml` reads the published version by grepping `pyproject.toml`, and CI's `uv sync` carries no `--locked`, so a stale lock is refreshed silently rather than failing. The practical cost is that the next person to run `uv lock` picks up an unrelated one-line diff in their PR.

## Change

Ran `uv lock` (`Updated askcc v0.2.14 -> v0.2.15`). Single-line change to `uv.lock`; no dependency resolution changed.

This matches the repo's usual practice — `c4ab6a9`, `8cdb15e`, `a23317b`, `c84865f`, and `35b8959` all committed `uv.lock` alongside a version bump.

## Test plan

- [x] `uv lock --check` — lock is current against `pyproject.toml`
- [x] Diff vs `main` is `uv.lock` only, one line